### PR TITLE
Change currentTimeMillis() for nanoTime()

### DIFF
--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -37,7 +37,7 @@ public final class Matrix implements Serializable {
 		matrix = new double[r * c];
 		rows = r;
 		cols = c;
-		seed = System.currentTimeMillis();
+		seed = System.nanoTime();
 		//seed = 0;
 
 		if (identity) {


### PR DESCRIPTION
I've been writing and running some tests and found a somewhat troubling behavior, multiple invocations to `Matrix.random()` will return the exact same matrix...

```java
    @Test
    public void testRandomIntInt() {
        Matrix a = Matrix.random(15, 10);
        Matrix b = Matrix.random(15, 10);
        assertNotEquals(a, b);
    }
```

This is actually fascinating, I wrote the tests on my laptop and the work perfectly and when I got home they didn't work (I don't own a very good laptop...),

The proposed change is simply to make the tests work, but in the future I much rather pass a `Random` object to random initializers, and use `ThreadLocalRandom.current()` for uninitialized random objects.