### PR TITLE
Minor nitpick when populating the identity matrix

### DIFF
--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -64,7 +64,7 @@ public final class Matrix implements Serializable {
 		//seed = 0;
 
 		if (identity) {
-			for (int i = 0, m = r < c ? r : c; i < m; i++)
+			for (int i = 0, m = Math.min(r, c); i < m; i++)
 				matrix[i * c + i] = 1;
 		}
 	}

--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -64,9 +64,8 @@ public final class Matrix implements Serializable {
 		//seed = 0;
 
 		if (identity) {
-			for (int i = 0; i < r; i++)
-				for (int j = 0; j < c; j++)
-					matrix[i * cols + j] = i == j ? 1 : 0;
+			for (int i = 0, m = r < c ? r : c; i < m; i++)
+				matrix[i * c + i] = 1;
 		}
 	}
 


### PR DESCRIPTION
Since double arrays are already zero-filled on creation, there's no need to traverse the array filling it with zeros.