### PR TITLE
"Fix" javadoc

### DIFF
--- a/src/libai/ants/Enviroment.java
+++ b/src/libai/ants/Enviroment.java
@@ -74,6 +74,7 @@ public class Enviroment {
 	 * Constructor. Allocates only the Graph and the pheromone trail
 	 *
 	 * @param G the graph with the problem related information
+	 * @param randomPheromones {@code randomPheromones}
 	 */
 	public Enviroment(Graph G, boolean randomPheromones) {
 		this.setGraph(G);
@@ -102,6 +103,7 @@ public class Enviroment {
 	 *
 	 * @param numberOfAnts the number of ants to use
 	 * @param G the graph with the problem related information
+	 * @param randomPheromones {@code randomPheromones}
 	 * @throws AntFrameworkException if numberOfAnts is less or equal to 0
 	 */
 	public Enviroment(int numberOfAnts, Graph G, boolean randomPheromones) throws AntFrameworkException {
@@ -120,6 +122,7 @@ public class Enviroment {
 	 * @param numberOfAnts number of ants
 	 * @param G object Graph
 	 * @param v initial value of the pheromone trail
+	 * @throws libai.ants.AntFrameworkException AntFrameworkException
 	 */
 	public Enviroment(int numberOfAnts, Graph G, double v) throws AntFrameworkException {
 		this(numberOfAnts, G, false);
@@ -130,7 +133,7 @@ public class Enviroment {
 	/**
 	 * Sets the number of ants of this Enviroment
 	 *
-	 * @param numberOfAnts
+	 * @param numberOfAnts  {@code numberOfAnts}
 	 */
 	public void setNumberOfAnts(int numberOfAnts) {
 		this.numberOfAnts = numberOfAnts;
@@ -157,6 +160,7 @@ public class Enviroment {
 
 	/**
 	 * Sets the array of ants of this enviroment.
+	 * @throws libai.ants.AntFrameworkException AntFrameworkException
 	 */
 	public void setAnts() throws AntFrameworkException {
 		if (this.numberOfAnts <= 0) {

--- a/src/libai/ants/Enviroment.java
+++ b/src/libai/ants/Enviroment.java
@@ -174,7 +174,7 @@ public class Enviroment {
 	 * Sets both the number of ants and the array of ants
 	 *
 	 * @param numberOfAnts number of ants
-	 * @throws AntFrameworkException if number of ants is <= 0
+	 * @throws AntFrameworkException if number of ants is &lt;= 0
 	 */
 	public void setAnts(int numberOfAnts) throws AntFrameworkException {
 		this.setNumberOfAnts(numberOfAnts);

--- a/src/libai/ants/algorithms/AntColonySystem.java
+++ b/src/libai/ants/algorithms/AntColonySystem.java
@@ -289,6 +289,7 @@ public abstract class AntColonySystem extends Metaheuristic {
 	 * in the list.
 	 *
 	 * @param i source node
+	 * @param possibleNodes {@code possibleNodes}
 	 * @return destination node
 	 */
 	public int decisionRuleNotFromCandidate(int i, Vector<Integer> possibleNodes) {

--- a/src/libai/ants/algorithms/Metaheuristic.java
+++ b/src/libai/ants/algorithms/Metaheuristic.java
@@ -161,7 +161,7 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	/**
 	 * Sets the number of nodes of the graph problem
 	 *
-	 * @param numberOfNodes
+	 * @param numberOfNodes {@code numberOfNodes}
 	 */
 	public void setNumberOfNodes(int numberOfNodes) {
 		this.numberOfNodes = numberOfNodes;
@@ -197,6 +197,7 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	 * Used by ants to decided the next node to visit.
 	 *
 	 * @param i source node
+	 * @param currentSolution {@code currentSolution}
 	 * @return destination node
 	 */
 	abstract public int decisionRule(int i, Vector<Integer> currentSolution);
@@ -206,7 +207,7 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	 * calls to other functions: pheromonesUpdate,pheromonesEvaporation..
 	 * according to some ACO algorithm specific logic
 	 *
-	 * @throws AntFrameworkException
+	 * @throws AntFrameworkException AntFrameworkException
 	 */
 	abstract public void solve() throws AntFrameworkException;
 
@@ -216,7 +217,7 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	 * some other parameter do not exists but it is possible to set a default
 	 * value, here is the place to do it.
 	 *
-	 * @throws Exception
+	 * @throws Exception Exception
 	 */
 	abstract public void checkParameters() throws Exception;
 
@@ -240,6 +241,7 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	 *
 	 * @param i current node
 	 * @param currentSolution ant's current solutin
+	 * @return list of possible nodes to visit
 	 */
 	abstract public Vector<Integer> constrains(int i, Vector<Integer> currentSolution);
 

--- a/src/libai/classifiers/trees/C45.java
+++ b/src/libai/classifiers/trees/C45.java
@@ -119,6 +119,8 @@ public class C45 implements Comparable<C45> {
 
     /**
      * Return an unpruned tree from the given dataset.
+     * @param ds {@code ds}
+     * @return unpruned tree from the given dataset
      */
     public static C45 getInstance(DataSet ds) {
         return new C45().train(ds);
@@ -127,6 +129,9 @@ public class C45 implements Comparable<C45> {
     /**
      * Return a pruned tree from the given dataset using the standard confidence
      * of 25%
+     * @param ds {@code ds}
+     * @param type {@code type}
+     * @return pruned tree from the given dataset using the standard confidence
      */
     public static C45 getInstancePrune(DataSet ds, int type) {
         return new C45().train(ds).prune(ds, type);
@@ -135,6 +140,9 @@ public class C45 implements Comparable<C45> {
     /**
      * Return a pruned tree from the given dataset using the specified
      * confidence.
+     * @param ds {@code ds}
+     * @param confidence {@code confidence}
+     * @return pruned tree from the given dataset using the specified
      */
     public static C45 getInstancePrune(DataSet ds, double confidence) {
         C45 ret = new C45();
@@ -615,6 +623,8 @@ public class C45 implements Comparable<C45> {
     //IO functions
     /**
      * Load a new C45 tree from the XML node root.
+     * @param root {@code root}
+     * @return new C45 tree from the XML node root
      */
     protected C45 load(Node root) {
         if (root.getNodeName().equals("node")) {

--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -470,7 +470,7 @@ public final class Matrix implements Serializable {
 	 }
 	 */
 	/**
-	 * Print this matrix in the OpenOffice's formula format. Useful for copy &
+	 * Print this matrix in the OpenOffice's formula format. Useful for copy &amp;
 	 * paste in OO documents.
 	 *
 	 * @param out Stream to write on.

--- a/src/libai/common/functions/Function.java
+++ b/src/libai/common/functions/Function.java
@@ -26,7 +26,7 @@ package libai.common.functions;
 import java.io.Serializable;
 
 /**
- * Interface for real functions F(x): R -> R. If the function has a derivate, the
+ * Interface for real functions F(x): R -&gt; R. If the function has a derivate, the
  * method getDerivate() MUST be implemented and return a new object to handle
  * this derivate.
  *

--- a/src/libai/common/functions/Function.java
+++ b/src/libai/common/functions/Function.java
@@ -26,9 +26,9 @@ package libai.common.functions;
 import java.io.Serializable;
 
 /**
- * Interface for real functions F(x): R -&gt; R. If the function has a derivate, the
- * method getDerivate() MUST be implemented and return a new object to handle
- * this derivate.
+ * Interface for real functions F(x): R -&gt; R. If the function has a derivate,
+ * the method getDerivate() MUST be implemented and return a new object to 
+ * handle this derivate.
  *
  * @author kronenthaler
  */

--- a/src/libai/fuzzy/Engine.java
+++ b/src/libai/fuzzy/Engine.java
@@ -58,6 +58,7 @@ public class Engine {
 
 	/**
 	 * Constructor. Creates a Engine with verbose output.
+	 * @param _debug {@code _debug}
 	 */
 	public Engine(boolean _debug) {
 		this();

--- a/src/libai/fuzzy/Variable.java
+++ b/src/libai/fuzzy/Variable.java
@@ -26,7 +26,7 @@ package libai.fuzzy;
 /**
  * Wrapper around a double value. This implementation allows, change the type of
  * the double, for other types more precises or maybe any type suitable for
- * embebbed devices without change the structure of the rest of the engine.
+ * embedded devices without change the structure of the rest of the engine.
  *
  * @author kronenthaler
  */

--- a/src/libai/fuzzy/sets/FuzzySet.java
+++ b/src/libai/fuzzy/sets/FuzzySet.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 
 public interface FuzzySet {
 	/**
-	 * Evaluate the membership of the set with the especified value. Alias of
-	 * eval(s.getValue()).
+	 * Evaluate the membership of the set with the specified value. Alias of
+	 * {@code eval(s.getValue())}
 	 *
 	 * @param s Value to evaluate.
 	 * @return The membership value for the input.

--- a/src/libai/fuzzy/sets/FuzzySet.java
+++ b/src/libai/fuzzy/sets/FuzzySet.java
@@ -45,7 +45,7 @@ public interface FuzzySet {
 	public double eval(double s);
 
 	/**
-	 * Set of values where = {x e X | u(x) > 0}
+	 * Set of values where = {x e X | u(x) &gt; 0}
 	 *
 	 * @return The set of values where the membership is greater than zero.
 	 */

--- a/src/libai/fuzzy/sets/Trapezoid.java
+++ b/src/libai/fuzzy/sets/Trapezoid.java
@@ -28,15 +28,15 @@ import java.util.ArrayList;
 
 /**
  * Fuzzy set representing a trapezoid function. The trapezoid function can take
- * 3 variations: <br/>
+ * 3 variations: <br>
  * <ul>
  * <li>right trapezoid to the left. a = b != c != d.</li>
  * <li>centered trapezoid a != b != c != d.</li>
  * <li>right trapezoid to the right a != b != c = d.</li>
  * </ul>
  *
- * In the three cases, the support of the set is the interval [a,d].<br/>
- * The kernel is always the interval [b,c].<br/>
+ * In the three cases, the support of the set is the interval [a,d].<br>
+ * The kernel is always the interval [b,c].<br>
  *
  * @author kronenthaler
  */

--- a/src/libai/fuzzy/sets/Triangular.java
+++ b/src/libai/fuzzy/sets/Triangular.java
@@ -29,15 +29,15 @@ import java.util.ArrayList;
 /**
  * Fuzzy set representing a triangular function. Only one point on the function
  * can take the max value of 1. The triangular function can take 3 variations:
- * <br/>
+ * <br>
  * <ul>
  * <li>right triangle to the left. a = b != c.</li>
  * <li>centered triangle a != b != c.</li>
  * <li>right triangle to the right a != b = c.</li>
  * </ul>
  *
- * In the three cases, the support of the set is the interval [a,c].<br/>
- * The kernel is always the single value b.<br/>
+ * In the three cases, the support of the set is the interval [a,c].<br>
+ * The kernel is always the single value b.<br>
  *
  * @author kronenthaler
  */

--- a/src/libai/genetics/Engine.java
+++ b/src/libai/genetics/Engine.java
@@ -29,10 +29,10 @@ import java.util.Random;
 
 /**
  * Engine class provides complete algorithm to evolve populations of
- * chormosomes, regardless of these kind. This implementation of the genetic
- * algorithm contemplates the ellitism variant for the selection. The mutation
+ * chromosomes, regardless of these kind. This implementation of the genetic
+ * algorithm contemplates the elitism variant for the selection. The mutation
  * and cross are more chromosome-dependent that the algorithm-dependent,
- * therefore, chromosomes are instantiated for its class and evaluateds through
+ * therefore, chromosomes are instantiated for its class and evaluated through
  * the Fitness instance.
  *
  * @author kronenthaler
@@ -47,7 +47,7 @@ public class Engine {
 	 */
 	private Chromosome newpopulation[];
 	/**
-	 * The chrmosomes selected to crossing
+	 * The chromosomes selected to crossing
 	 */
 	private Chromosome toCross[];
 	/**
@@ -161,7 +161,7 @@ public class Engine {
 	}
 
 	/**
-	 * Cross population. Elitish style.
+	 * Cross population. Elitist style.
 	 */
 	private void cross() {
 		int a = 0, b = 0, pos = 0, j = 0, i = 0;

--- a/src/libai/genetics/Engine.java
+++ b/src/libai/genetics/Engine.java
@@ -199,6 +199,7 @@ public class Engine {
 	 * Evolve the population for
 	 * <code>ages</code>
 	 *
+	 * @param ages {@code ages}
 	 * @return The best chromosome for all these epochs.
 	 */
 	public Chromosome evolve(int ages) {

--- a/src/libai/genetics/Fitness.java
+++ b/src/libai/genetics/Fitness.java
@@ -32,7 +32,7 @@ import libai.genetics.chromosomes.Chromosome;
  */
 public interface Fitness {
 	/**
-	 * evaluate the fitnes of the passed chromosome.
+	 * evaluate the fitness of the passed chromosome.
 	 * @param c  {@code c}
 	 * @return fitness value for a given Chromosome
 	 */
@@ -48,8 +48,8 @@ public interface Fitness {
 	public boolean isBetter(double fitness, double best);
 
 	/**
-	 * the worst posible value OO or -OO
-	 * @return worst posible value OO or -OO
+	 * the worst possible value OO or -OO
+	 * @return worst possible value OO or -OO
 	 */
 	public double theWorst();
 }

--- a/src/libai/genetics/Fitness.java
+++ b/src/libai/genetics/Fitness.java
@@ -33,16 +33,23 @@ import libai.genetics.chromosomes.Chromosome;
 public interface Fitness {
 	/**
 	 * evaluate the fitnes of the passed chromosome.
+	 * @param c  {@code c}
+	 * @return fitness value for a given Chromosome
 	 */
 	public double fitness(Chromosome c);
 
 	/**
 	 * is this fitness better than the best fitness known?
+	 * @param fitness {@code fitness}
+	 * @param best {@code best}
+	 * @return {@code true} is this fitness better than the best fitness and
+	 * {@code false} otherwise
 	 */
 	public boolean isBetter(double fitness, double best);
 
 	/**
 	 * the worst posible value OO or -OO
+	 * @return worst posible value OO or -OO
 	 */
 	public double theWorst();
 }

--- a/src/libai/genetics/chromosomes/BinaryChromosome.java
+++ b/src/libai/genetics/chromosomes/BinaryChromosome.java
@@ -138,6 +138,8 @@ public class BinaryChromosome extends Chromosome {
 	 * as reference. If the chromosome is too large this value can be
 	 * overflowed.
 	 *
+	 * @param minValue {@code minValue}
+	 * @param maxValue {@code maxValue}
 	 * @return The double representation of the chromosome.
 	 */
 	public double decode(double minValue, double maxValue) {

--- a/src/libai/genetics/chromosomes/BinaryChromosome.java
+++ b/src/libai/genetics/chromosomes/BinaryChromosome.java
@@ -29,9 +29,9 @@ import java.util.BitSet;
 /**
  * The binary form of the chormosome. This chromosome contains a sequence of
  * bits. The mutation operation are supported by flipping a bit. And the cross
- * by masking the bits:<br/>
- * offspring1: (this & mask) | (otherparent & ~mask)<br/>
- * offspring2: (otherparent & mask) | (this & ~mask)<br/>
+ * by masking the bits:<br>
+ * offspring1: (this &amp; mask) | (otherparent &amp; ~mask)<br>
+ * offspring2: (otherparent &amp; mask) | (this &amp; ~mask)<br>
  *
  * @author kronenthaler
  */

--- a/src/libai/genetics/chromosomes/BinaryChromosome.java
+++ b/src/libai/genetics/chromosomes/BinaryChromosome.java
@@ -27,7 +27,7 @@ import libai.genetics.Engine;
 import java.util.BitSet;
 
 /**
- * The binary form of the chormosome. This chromosome contains a sequence of
+ * The binary form of the chromosome. This chromosome contains a sequence of
  * bits. The mutation operation are supported by flipping a bit. And the cross
  * by masking the bits:<br>
  * offspring1: (this &amp; mask) | (otherparent &amp; ~mask)<br>
@@ -67,7 +67,7 @@ public class BinaryChromosome extends Chromosome {
 
 	/**
 	 * Split the genes by <i>position</i> and swap lower portion of this with
-	 * the lower portion of b and viceversa to return 2 offsprings.
+	 * the lower portion of b and vice versa to return 2 offsprings.
 	 *
 	 * @param b chromosome to cross
 	 * @param position Position to split the chromosomes.

--- a/src/libai/genetics/chromosomes/Chromosome.java
+++ b/src/libai/genetics/chromosomes/Chromosome.java
@@ -46,21 +46,29 @@ public abstract class Chromosome {
 	 * <code>position</code> and swap lower portion of this with the lower
 	 * portion of
 	 * <code>b</code> and return the new individual
+	 * @param b {@code b}
+	 * @param position {@code position}
+	 * @return new individual
 	 */
 	public abstract Chromosome[] cross(Chromosome b, int position);
 
 	/**
 	 * Change one gene of the chromosome
+	 * @param pm {@code pm}
+	 * @return mutated {@code Chromosome}
 	 */
 	public abstract Chromosome mutate(double pm);
 
 	/**
 	 * Copy constructor
+	 * @return copy of this Chromosome
 	 */
 	public abstract Chromosome getCopy();
 
 	/**
 	 * Generic constructor
+	 * @param length {@code length}
+	 * @return {@code Chromosome} instance
 	 */
 	public abstract Chromosome getInstance(int length);
 

--- a/src/libai/nn/NeuralNetwork.java
+++ b/src/libai/nn/NeuralNetwork.java
@@ -211,6 +211,8 @@ public abstract class NeuralNetwork implements Serializable {
 	 * <code>sigma</code> and input parameter
 	 * <code>u^2</code>
 	 *
+	 * @param u2  {@code u2}
+	 * @param sigma  {@code sigma}
 	 * @return e^(-u^2/2.sigma)
 	 */
 	public static double gaussian(double u2, double sigma) {

--- a/src/libai/nn/supervised/Adaline.java
+++ b/src/libai/nn/supervised/Adaline.java
@@ -28,9 +28,10 @@ import libai.common.Matrix;
 
 /**
  * <b>Ada</b>ptative <b>Line</b>ar neural network. Is a special case of the
- * single layer Perceptron. Uses a identity as exit function. The only diference
- * between the trainning algorithms is the 2*alpha multiplication. Because of
- * this, the Adaline implementation is a subclass of perceptron single layer.
+ * single layer Perceptron. Uses a identity as exit function. The only 
+ * difference between the training algorithms is the 2*alpha multiplication. 
+ * Because of this, the Adaline implementation is a subclass of Perceptron 
+ * single layer.
  *
  * @author kronenthaler
  */

--- a/src/libai/nn/supervised/MLP.java
+++ b/src/libai/nn/supervised/MLP.java
@@ -167,9 +167,9 @@ public class MLP extends NeuralNetwork {
 	 * Then the error for the final layer is computed. The error is calculated
 	 * backwards to the first hidden layer, calculating the diferentials between
 	 * input and expected output (backpropagation). Finally, the weights and
-	 * biases are updated using the delta rule:<br/>
-	 * W[i] = W[i] + beta*(W[i]-Wprev[i]) - (1-beta)*alpha.d[i].Y[i-1]^t <br/>
-	 * B[i] = B[i] + beta*(B[i]-Bprev[i]) - (1-beta)*alpha.d[i]<br/>
+	 * biases are updated using the delta rule:<br>
+	 * W[i] = W[i] + beta*(W[i]-Wprev[i]) - (1-beta)*alpha.d[i].Y[i-1]^t <br>
+	 * B[i] = B[i] + beta*(B[i]-Bprev[i]) - (1-beta)*alpha.d[i]<br>
 	 *
 	 * @param patterns	The patterns to be learned.
 	 * @param answers The expected answers.

--- a/src/libai/nn/supervised/MLP.java
+++ b/src/libai/nn/supervised/MLP.java
@@ -34,7 +34,7 @@ import libai.nn.NeuralNetwork;
  * Multi Layer Perceptron or MLP. MLP was the first algorithm proposed to train
  * multilayer neurons using the general delta rule. This implementation has the
  * classical backpropagation algorithm and the main variant the backpropagation
- * with momemtum. NOTE: The backpropagation is a very slow algorithm involves
+ * with momentum. NOTE: The backpropagation is a very slow algorithm involves
  * MANY matrix operation. I have planned to implement a batch algorithm or
  * Resilent Backpropagation (Rprop) to replace this algorithm. Meanwhile be
  * patient.
@@ -80,7 +80,7 @@ public class MLP extends NeuralNetwork {
 	 * <code>nperlayer</code>. The nperlayer[0] means the input layer. For each
 	 * layer the neurons appliss the output function
 	 * <code>funcs[i]</code>. These functions must be derivable. The parameter
-	 * <code>beta</code> means the momemtum influence. If beta &lt;= 0 the
+	 * <code>beta</code> means the momentum influence. If beta &lt;= 0 the
 	 * momentum has no influence. if beta &gt; 0 and &lt; 1 that's the
 	 * influence.
 	 *
@@ -135,7 +135,7 @@ public class MLP extends NeuralNetwork {
 	}
 
 	/**
-	 * Initialize the matrix and auxiliar buffers.
+	 * Initialize the matrix and auxiliary buffers.
 	 */
 	private void init() {
 		Yt[0] = new Matrix(1, nperlayer[0]);
@@ -165,9 +165,9 @@ public class MLP extends NeuralNetwork {
 	 * Train the network using the standard backpropagation algorithm. The
 	 * pattern is propagated from the input to the final layer (the output).
 	 * Then the error for the final layer is computed. The error is calculated
-	 * backwards to the first hidden layer, calculating the diferentials between
-	 * input and expected output (backpropagation). Finally, the weights and
-	 * biases are updated using the delta rule:<br>
+	 * backwards to the first hidden layer, calculating the differentials 
+	 * between input and expected output (backpropagation). Finally, the weights 
+	 * and biases are updated using the delta rule:<br>
 	 * W[i] = W[i] + beta*(W[i]-Wprev[i]) - (1-beta)*alpha.d[i].Y[i-1]^t <br>
 	 * B[i] = B[i] + beta*(B[i]-Bprev[i]) - (1-beta)*alpha.d[i]<br>
 	 *

--- a/src/libai/nn/supervised/Perceptron.java
+++ b/src/libai/nn/supervised/Perceptron.java
@@ -64,8 +64,8 @@ public class Perceptron extends NeuralNetwork {
 	}
 
 	/**
-	 * Train the perceptron using the standard update rule: <br/>
-	 * W = W + alpha.e.pattern^t<br/>
+	 * Train the perceptron using the standard update rule: <br>
+	 * W = W + alpha.e.pattern^t<br>
 	 * b = b + alpha.e
 	 *
 	 * @param patterns	The patterns to be learned.

--- a/src/libai/nn/supervised/RBF.java
+++ b/src/libai/nn/supervised/RBF.java
@@ -32,7 +32,7 @@ import libai.nn.NeuralNetwork;
 /**
  * Radial Basis Function or RBF. Is an hybrid neural network with 3 layers
  * (1-input, 1-hidden, 1-output). The hidden layers is trained using a
- * stochactic clustering algorithm: k-means. The final layer is trained using
+ * stochastic clustering algorithm: k-means. The final layer is trained using
  * the Adaline rule. The k-means algorithm is used to set up the position of the
  * "centers" of the radial basis functions, as this process is regardless of the
  * output and invariant over the input, could be used a highly efficient
@@ -70,7 +70,7 @@ public class RBF extends Adaline {
 	 * radial basis functions using k-means algorithm. After that the radius of
 	 * the function is calculated using n-nearest neighbors. When n = the number
 	 * of inputs. Then the output for the hidden layer are precalculated and
-	 * used as input for the Adaline trainning.
+	 * used as input for the Adaline training.
 	 *
 	 * @param patterns	The patterns to be learned.
 	 * @param answers The expected answers.
@@ -222,7 +222,7 @@ public class RBF extends Adaline {
 
 	/**
 	 * Calculate the distance from the pattern to each centroid and apply the
-	 * gaussian function to that distance left the result in
+	 * Gaussian function to that distance left the result in
 	 * <code>result</code>.
 	 *
 	 * @param pattern Pattern to evaluate

--- a/src/libai/nn/supervised/SVM.java
+++ b/src/libai/nn/supervised/SVM.java
@@ -34,9 +34,9 @@ import libai.nn.NeuralNetwork;
 
 /**
  * Implementation of the SVM using the SMO algorithm. Based on the original
- * implementation of:<br/>
+ * implementation of:<br>
  * X. Jiang and H. Yu. SVM-JAVA: A Java implementation of the SMO (Sequential
- * Minimal Optimization) for training SVM.<br/>
+ * Minimal Optimization) for training SVM.<br>
  * Department of Computer Science and Engineering, Pohang University of Science
  * and Technology (POSTECH), http://iis.hwanjoyu.org/svm-java, 2008. The code
  * was adapted to the data structures and architecture of the libai. Some little

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -74,8 +74,8 @@ public class Competitive extends NeuralNetwork {
 	/**
 	 * Train the network using "the winner takes all". For each neuron the
 	 * Euclidean distance between the pattern and the neuron is calculated. The
-	 * position with the lowest distance is updated with the rule:<br/>
-	 * Ww = Ww + alpha.(pattern - Ww)<br/>
+	 * position with the lowest distance is updated with the rule:<br>
+	 * Ww = Ww + alpha.(pattern - Ww)<br>
 	 *
 	 * @param patterns	The patterns to be learned.
 	 * @param answers The expected answers.

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -32,7 +32,7 @@ import libai.nn.NeuralNetwork;
 /**
  * Competitive Learning is an unsupervised network where "the winner takes all".
  * A pattern is presented to each neuron, the closest neuron wins the right to
- * be updated. The update makes this neuron fitest for that pattern in the
+ * be updated. The update makes this neuron fittest for that pattern in the
  * future. Finally, the network learns a set of descriptive patterns or
  * centroids (if is compared with a clustering algorithm). In general, the
  * output for that network will be a binary codified class, when only one bit on
@@ -174,7 +174,7 @@ public class Competitive extends NeuralNetwork {
 
 	/**
 	 * Calculate the error using the average distance between the closest
-	 * neuron. Less distance means less error and viceversa.
+	 * neuron. Less distance means less error and vice versa.
 	 *
 	 * @param patterns The array with the patterns to test
 	 * @param answers The array with the expected answers for the patterns.

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -35,7 +35,7 @@ import libai.nn.NeuralNetwork;
  * autoassociative network consists in to learn the same input pattern as output
  * pattern. This networks just is able to learn binary patterns because its
  * output function (sign). The Hebbian networks uses the Hebb's rule for
- * trainning. The Hebb's rule is one of the most important training rules in
+ * training. The Hebb's rule is one of the most important training rules in
  * unsupervised networks. Other algorithms like Kohonen uses this rule as base.
  *
  * @author kronenthaler

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -34,10 +34,10 @@ import libai.nn.NeuralNetwork;
  * Kohonen's Self-organizative Maps or SOM or Kohonen. This maps are one of the
  * most important unsupervised neural networks of the history. The most
  * important feature of the kohonen's maps is the possibility of transform any
- * multidimensional space into a R^2 space, providing a highly precise clusteing
- * method. One of the most famous examples for the kohonen's maps is the
- * transform the RGB color cube into a plane where the reds, greens, blues, etc
- * are clustered in a very similar way of the any color picker utility.
+ * multidimensional space into a R^2 space, providing a highly precise 
+ * clustering method. One of the most famous examples for the kohonen's maps is 
+ * the transform the RGB color cube into a plane where the reds, greens, blues, 
+ * etc are clustered in a very similar way of the any color picker utility.
  *
  * @author kronenthaler
  */

--- a/src/libai/search/State.java
+++ b/src/libai/search/State.java
@@ -32,16 +32,19 @@ import java.util.*;
 public abstract class State implements Comparable<State> {
 	/**
 	 * Get the cost of the current state
+	 * @return cost of the current state
 	 */
 	public abstract double getCost();
 
 	/**
 	 * Get the heuristic cost of the current state
+	 * @return heuristic cost of the current state
 	 */
 	public abstract double getHeuristicCost();
 
 	/**
 	 * Returns a list with all the possible candidates from this state
+	 * @return list with all the possible candidates from this state
 	 */
 	public abstract ArrayList<State> getCandidates();
 
@@ -58,6 +61,7 @@ public abstract class State implements Comparable<State> {
 
 	/**
 	 * Determines if two states are equals or equivalents
+	 * @param o {@code o}
 	 */
 	public boolean equals(Object o) {
 		return compareTo((State) o) == 0;
@@ -65,6 +69,8 @@ public abstract class State implements Comparable<State> {
 
 	/**
 	 * Determines if the current state is a solution or not
+	 * @return {@code true} if the current state is a solution and 
+	 * {@code false otherwise}
 	 */
 	public abstract boolean isSolution();
 }


### PR DESCRIPTION
The idea of this pull request is to make `JavaDoc` compile without errors (the latest `doclint` seems to randomly treat some very minor details as errors).

I simply completed the `@params` and `@return` tags with some boilerplate in order to make `JavaDoc` compile without warnings.

Also fix some minor typos I happen to see.

In time I'll try and actually improve the `JavaDocs`, but for that I really need to understand what the methods actually do... so I think I'll attempt to tackle this one class/package at a time.