### PR TITLE
Misc failsafe changes

### DIFF
--- a/src/Examples.java
+++ b/src/Examples.java
@@ -142,6 +142,7 @@ public class Examples extends javax.swing.JFrame {
 	 */
 	public static void main(String args[]) {
 		java.awt.EventQueue.invokeLater(new Runnable() {
+			@Override
 			public void run() {
 				new Examples().setVisible(true);
 			}

--- a/src/demos/ants/AntColonySystemPanel.java
+++ b/src/demos/ants/AntColonySystemPanel.java
@@ -124,6 +124,7 @@ public class AntColonySystemPanel extends javax.swing.JPanel {
 			jProgressBar1.setValue(0);
 
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (as.getCurrentIterationNumber() < jProgressBar1.getMaximum()) {
 						jProgressBar1.setValue(as.getCurrentIterationNumber());
@@ -218,6 +219,7 @@ public class AntColonySystemPanel extends javax.swing.JPanel {
 			this.setE(Env);
 		}
 
+		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
 			Vector<Integer> adjacents = new Vector<Integer>();
@@ -231,6 +233,7 @@ public class AntColonySystemPanel extends javax.swing.JPanel {
 			return adjacents;
 		}
 
+		@Override
 		public void candidateList(int max) {
 			Matrix G = this.Graph.getM();
 			int rows = G.getRows(), cols = G.getColumns(), cont;
@@ -255,6 +258,7 @@ public class AntColonySystemPanel extends javax.swing.JPanel {
 			}
 		}
 
+		@Override
 		public double heuristicInfo(double number) {
 			return 1.0 / number;
 		}

--- a/src/demos/ants/AntColonySystemPanel.java
+++ b/src/demos/ants/AntColonySystemPanel.java
@@ -222,7 +222,7 @@ public class AntColonySystemPanel extends javax.swing.JPanel {
 		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
-			Vector<Integer> adjacents = new Vector<Integer>();
+			Vector<Integer> adjacents = new Vector<>();
 			//Calculate adjancent nodes
 			for (int j = 0; j < cols; j++) {
 				if (this.Graph.getM().position(i, j) < Integer.MAX_VALUE) {
@@ -240,7 +240,7 @@ public class AntColonySystemPanel extends javax.swing.JPanel {
 
 			for (int i = 0; i < rows; i++) {
 				cont = 0;
-				Vector<Node> nodes = new Vector<Node>();
+				Vector<Node> nodes = new Vector<>();
 				for (int j = 0; j < cols; j++) {
 					if ((G.position(i, j) < Integer.MAX_VALUE)) {
 						Node nodeTmp = new Node(j, G.position(i, j), 1 / G.position(i, j));

--- a/src/demos/ants/AntQPanel.java
+++ b/src/demos/ants/AntQPanel.java
@@ -227,7 +227,7 @@ public class AntQPanel extends javax.swing.JPanel {
 		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
-			Vector<Integer> adjacents = new Vector<Integer>();
+			Vector<Integer> adjacents = new Vector<>();
 			//Calculate adjancent nodes
 			for (int j = 0; j < cols; j++) {
 				if (this.Graph.getM().position(i, j) < Integer.MAX_VALUE) {
@@ -245,7 +245,7 @@ public class AntQPanel extends javax.swing.JPanel {
 
 			for (int i = 0; i < rows; i++) {
 				cont = 0;
-				Vector<Node> nodes = new Vector<Node>();
+				Vector<Node> nodes = new Vector<>();
 				for (int j = 0; j < cols; j++) {
 					if ((G.position(i, j) < Integer.MAX_VALUE)) {
 						Node nodeTmp = new Node(j, G.position(i, j), 1 / G.position(i, j));

--- a/src/demos/ants/AntQPanel.java
+++ b/src/demos/ants/AntQPanel.java
@@ -124,6 +124,7 @@ public class AntQPanel extends javax.swing.JPanel {
 			jProgressBar1.setValue(0);
 
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (as.getCurrentIterationNumber() < jProgressBar1.getMaximum()) {
 						jProgressBar1.setValue(as.getCurrentIterationNumber());
@@ -223,6 +224,7 @@ public class AntQPanel extends javax.swing.JPanel {
 			this.setE(Env);
 		}
 
+		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
 			Vector<Integer> adjacents = new Vector<Integer>();
@@ -236,6 +238,7 @@ public class AntQPanel extends javax.swing.JPanel {
 			return adjacents;
 		}
 
+		@Override
 		public void candidateList(int max) {
 			Matrix G = this.Graph.getM();
 			int rows = G.getRows(), cols = G.getColumns(), cont;
@@ -260,6 +263,7 @@ public class AntQPanel extends javax.swing.JPanel {
 			}
 		}
 
+		@Override
 		public double heuristicInfo(double number) {
 			return 1 / number;
 		}

--- a/src/demos/ants/AntSystemPanel.java
+++ b/src/demos/ants/AntSystemPanel.java
@@ -220,7 +220,7 @@ public class AntSystemPanel extends javax.swing.JPanel {
 		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
-			Vector<Integer> adjacents = new Vector<Integer>();
+			Vector<Integer> adjacents = new Vector<>();
 			//Calculate adjancent nodes
 			for (int j = 0; j < cols; j++) {
 				if (this.Graph.getM().position(i, j) < Integer.MAX_VALUE) {

--- a/src/demos/ants/AntSystemPanel.java
+++ b/src/demos/ants/AntSystemPanel.java
@@ -122,6 +122,7 @@ public class AntSystemPanel extends javax.swing.JPanel {
 			jProgressBar1.setValue(0);
 
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (as.getCurrentIterationNumber() < jProgressBar1.getMaximum()) {
 						jProgressBar1.setValue(as.getCurrentIterationNumber());
@@ -201,6 +202,7 @@ public class AntSystemPanel extends javax.swing.JPanel {
 			this.setE(Env);
 		}
 
+		@Override
 		public double heuristicInfo(double number) {
 			return 1.0 / number;
 		}
@@ -215,6 +217,7 @@ public class AntSystemPanel extends javax.swing.JPanel {
 			}
 		}
 
+		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
 			Vector<Integer> adjacents = new Vector<Integer>();

--- a/src/demos/ants/AntSystemRankPanel.java
+++ b/src/demos/ants/AntSystemRankPanel.java
@@ -223,7 +223,7 @@ public class AntSystemRankPanel extends javax.swing.JPanel {
 		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
-			Vector<Integer> adjacents = new Vector<Integer>();
+			Vector<Integer> adjacents = new Vector<>();
 			//Calculate adjancent nodes
 			for (int j = 0; j < cols; j++) {
 				if (this.Graph.getM().position(i, j) < Integer.MAX_VALUE) {

--- a/src/demos/ants/AntSystemRankPanel.java
+++ b/src/demos/ants/AntSystemRankPanel.java
@@ -122,6 +122,7 @@ public class AntSystemRankPanel extends javax.swing.JPanel {
 			jProgressBar1.setValue(0);
 
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (as.getCurrentIterationNumber() < jProgressBar1.getMaximum()) {
 						jProgressBar1.setValue(as.getCurrentIterationNumber());
@@ -204,6 +205,7 @@ public class AntSystemRankPanel extends javax.swing.JPanel {
 			this.setE(Env);
 		}
 
+		@Override
 		public double heuristicInfo(double number) {
 			return 1 / number;
 		}
@@ -218,6 +220,7 @@ public class AntSystemRankPanel extends javax.swing.JPanel {
 			}
 		}
 
+		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
 			Vector<Integer> adjacents = new Vector<Integer>();

--- a/src/demos/ants/ElitistAntSystemPanel.java
+++ b/src/demos/ants/ElitistAntSystemPanel.java
@@ -122,6 +122,7 @@ public class ElitistAntSystemPanel extends javax.swing.JPanel {
 			jProgressBar1.setValue(0);
 
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (as.getCurrentIterationNumber() < jProgressBar1.getMaximum()) {
 						jProgressBar1.setValue(as.getCurrentIterationNumber());
@@ -204,6 +205,7 @@ public class ElitistAntSystemPanel extends javax.swing.JPanel {
 			this.setE(Env);
 		}
 
+		@Override
 		public double heuristicInfo(double number) {
 			return 1 / number;
 		}
@@ -218,6 +220,7 @@ public class ElitistAntSystemPanel extends javax.swing.JPanel {
 			}
 		}
 
+		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
 			Vector<Integer> adjacents = new Vector<Integer>();

--- a/src/demos/ants/ElitistAntSystemPanel.java
+++ b/src/demos/ants/ElitistAntSystemPanel.java
@@ -223,7 +223,7 @@ public class ElitistAntSystemPanel extends javax.swing.JPanel {
 		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
-			Vector<Integer> adjacents = new Vector<Integer>();
+			Vector<Integer> adjacents = new Vector<>();
 			//Calculate adjancent nodes
 			for (int j = 0; j < cols; j++) {
 				if (this.Graph.getM().position(i, j) < Integer.MAX_VALUE) {

--- a/src/demos/ants/MMASPanel.java
+++ b/src/demos/ants/MMASPanel.java
@@ -122,6 +122,7 @@ public class MMASPanel extends javax.swing.JPanel {
 			jProgressBar1.setValue(0);
 
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (as.getCurrentIterationNumber() < jProgressBar1.getMaximum()) {
 						jProgressBar1.setValue(as.getCurrentIterationNumber());
@@ -212,6 +213,7 @@ public class MMASPanel extends javax.swing.JPanel {
 			this.setE(Env);
 		}
 
+		@Override
 		public double heuristicInfo(double number) {
 			return 1 / number;
 		}
@@ -226,6 +228,7 @@ public class MMASPanel extends javax.swing.JPanel {
 			}
 		}
 
+		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
 			Vector<Integer> adjacents = new Vector<Integer>();

--- a/src/demos/ants/MMASPanel.java
+++ b/src/demos/ants/MMASPanel.java
@@ -231,7 +231,7 @@ public class MMASPanel extends javax.swing.JPanel {
 		@Override
 		public Vector<Integer> constrains(int i, Vector<Integer> currentSolution) {
 			int cols = this.Graph.getM().getColumns();
-			Vector<Integer> adjacents = new Vector<Integer>();
+			Vector<Integer> adjacents = new Vector<>();
 			//Calculate adjancent nodes
 			for (int j = 0; j < cols; j++) {
 				if (this.Graph.getM().position(i, j) < Integer.MAX_VALUE) {

--- a/src/demos/common/SimplePlotter.java
+++ b/src/demos/common/SimplePlotter.java
@@ -34,7 +34,7 @@ public class SimplePlotter extends Canvas implements Plotter{
 	private int pixels = 3;
 
 	public SimplePlotter() {
-		errors = new ArrayList<Pair<Integer, Double>>();
+		errors = new ArrayList<>();
 		min = Double.MAX_VALUE;
 		max = Double.MIN_VALUE;
 	}
@@ -86,7 +86,7 @@ public class SimplePlotter extends Canvas implements Plotter{
 
 	@Override
 	public void setError(int epoch, double error) {
-		errors.add(new Pair<Integer, Double>(epoch, error));
+		errors.add(new Pair<>(epoch, error));
 		min = Math.min(min, error);
 		max = Math.max(max, error);
 

--- a/src/demos/fuzzy/FuzzyPanel.java
+++ b/src/demos/fuzzy/FuzzyPanel.java
@@ -207,6 +207,7 @@ public class FuzzyPanel extends javax.swing.JPanel {
 		} else {
 			jButton1.setText("Stop");
 			new Thread(new Runnable() {
+				@Override
 				public void run() {
 					while (!exit) {
 						engine.start();

--- a/src/demos/genetic/BinaryPanel.java
+++ b/src/demos/genetic/BinaryPanel.java
@@ -98,6 +98,7 @@ public class BinaryPanel extends javax.swing.JPanel implements Fitness {
 		jTextPane1.setText("");
 		final Fitness me = this;
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int MaxVal = 1;
 				int MinVal = 0;
@@ -121,15 +122,18 @@ public class BinaryPanel extends javax.swing.JPanel implements Fitness {
     private javax.swing.JTextPane jTextPane1;
     // End of variables declaration//GEN-END:variables
 
+	@Override
 	public double fitness(Chromosome c) {
 		double x = ((BinaryChromosome) c).decode(0, 1);
 		return Math.abs(Math.exp(-x) - x); //=>0 si son iguales,
 	}
 
+	@Override
 	public boolean isBetter(double fitness, double best) {
 		return fitness < best;
 	}
 
+	@Override
 	public double theWorst() {
 		return Double.MAX_VALUE;
 	}

--- a/src/demos/genetic/Permutation.java
+++ b/src/demos/genetic/Permutation.java
@@ -98,6 +98,7 @@ public class Permutation extends javax.swing.JPanel implements Fitness {
 		jTextPane1.setText("");
 		final Fitness me = this;
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				Engine engine = new Engine(IntegerChromosome.class, 200, 10, 0.6, 0.01, me);
 				engine.setProgressBar(jProgressBar1);
@@ -119,6 +120,7 @@ public class Permutation extends javax.swing.JPanel implements Fitness {
     private javax.swing.JTextPane jTextPane1;
     // End of variables declaration//GEN-END:variables
 
+	@Override
 	public double fitness(Chromosome c1) {
 		IntegerChromosome c = (IntegerChromosome) c1;
 		int g[] = c.getGenes();
@@ -130,10 +132,12 @@ public class Permutation extends javax.swing.JPanel implements Fitness {
 		return count;
 	}
 
+	@Override
 	public boolean isBetter(double fitness, double best) {
 		return fitness < best;
 	}
 
+	@Override
 	public double theWorst() {
 		return Double.MAX_VALUE;
 	}

--- a/src/demos/nn/CompetitivePanel.java
+++ b/src/demos/nn/CompetitivePanel.java
@@ -100,6 +100,7 @@ public class CompetitivePanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 6;
 				int m = 2;

--- a/src/demos/nn/HopfieldPanel.java
+++ b/src/demos/nn/HopfieldPanel.java
@@ -385,6 +385,7 @@ public class HopfieldPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 2;
 				int m = 25;

--- a/src/demos/nn/KohonenPanel.java
+++ b/src/demos/nn/KohonenPanel.java
@@ -136,6 +136,7 @@ public class KohonenPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int t = 0;
 				int r = 0, g = 0, b = 0;

--- a/src/demos/nn/LVQPanel.java
+++ b/src/demos/nn/LVQPanel.java
@@ -101,6 +101,7 @@ public class LVQPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 6;
 				int m = 2;

--- a/src/demos/nn/MPLPanel.java
+++ b/src/demos/nn/MPLPanel.java
@@ -109,6 +109,7 @@ public class MPLPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 40;
 				int m = 1;

--- a/src/demos/nn/PerceptronPanel.java
+++ b/src/demos/nn/PerceptronPanel.java
@@ -97,6 +97,7 @@ public class PerceptronPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 40;
 				int t = 10;

--- a/src/demos/nn/RBFPanel.java
+++ b/src/demos/nn/RBFPanel.java
@@ -100,6 +100,7 @@ public class RBFPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 40;
 				int m = 1;

--- a/src/demos/nn/SVMPanel.java
+++ b/src/demos/nn/SVMPanel.java
@@ -100,6 +100,7 @@ public class SVMPanel extends javax.swing.JPanel {
 	private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
 		jTextPane1.setText("");
 		new Thread(new Runnable() {
+			@Override
 			public void run() {
 				int n = 100;
 				int t = 40;

--- a/src/demos/search/AStarPanel.java
+++ b/src/demos/search/AStarPanel.java
@@ -186,7 +186,7 @@ public class AStarPanel extends javax.swing.JPanel {
 		@Override
 		public ArrayList<State> getCandidates() {
 			//do until 4 moves.
-			ArrayList<State> candidates = new ArrayList<State>();
+			ArrayList<State> candidates = new ArrayList<>();
 			int row = point / 3;
 			int col = point % 3;
 			for (int i = 0; i < 4; i++) {

--- a/src/demos/search/BFSPanel.java
+++ b/src/demos/search/BFSPanel.java
@@ -177,7 +177,7 @@ public class BFSPanel extends javax.swing.JPanel {
 		@Override
 		public ArrayList<State> getCandidates() {
 			//do until 4 moves.
-			ArrayList<State> candidates = new ArrayList<State>();
+			ArrayList<State> candidates = new ArrayList<>();
 			int row = point / 3;
 			int col = point % 3;
 			for (int i = 0; i < 4; i++) {

--- a/src/demos/search/BFSPanel.java
+++ b/src/demos/search/BFSPanel.java
@@ -202,6 +202,7 @@ public class BFSPanel extends javax.swing.JPanel {
 			return table.compareTo(((Node) o).table);
 		}
 
+		@Override
 		public String toString() {
 			return table;
 		}

--- a/src/demos/search/DFSPanel.java
+++ b/src/demos/search/DFSPanel.java
@@ -177,7 +177,7 @@ public class DFSPanel extends javax.swing.JPanel {
 		@Override
 		public ArrayList<State> getCandidates() {
 			//do until 4 moves.
-			ArrayList<State> candidates = new ArrayList<State>();
+			ArrayList<State> candidates = new ArrayList<>();
 			int row = point / 3;
 			int col = point % 3;
 			for (int i = 0; i < 4; i++) {

--- a/src/demos/search/DFSPanel.java
+++ b/src/demos/search/DFSPanel.java
@@ -202,6 +202,7 @@ public class DFSPanel extends javax.swing.JPanel {
 			return table.compareTo(((Node) o).table);
 		}
 
+		@Override
 		public String toString() {
 			return table;
 		}

--- a/src/libai/ants/Ant.java
+++ b/src/libai/ants/Ant.java
@@ -59,7 +59,7 @@ public class Ant {
 	protected Ant(int index, int initialPos) {
 		this.index = index;
 		this.currentPos = initialPos;
-		this.solution = new Vector<Integer>();
+		this.solution = new Vector<>();
 	}
 
 	/**
@@ -102,7 +102,7 @@ public class Ant {
 	 * @return a copy of the Vector with the ant's current solution
 	 */
 	public Vector<Integer> copySolution() {
-		return new Vector<Integer>(this.solution);
+		return new Vector<>(this.solution);
 	}
 
 	/**

--- a/src/libai/ants/Graph.java
+++ b/src/libai/ants/Graph.java
@@ -57,10 +57,12 @@ public class Graph {
 	 */
 	public Graph(String fileSource) throws Exception {
 		this.setFileSource(fileSource);
-		ObjectInputStream in = new ObjectInputStream(new FileInputStream(fileSource));
-		Matrix m = (Matrix) in.readObject();
-		in.close();
-		this.setM(m);
+		
+		try (FileInputStream fis = new FileInputStream(fileSource);
+			 ObjectInputStream ois = new ObjectInputStream(fis)) {
+			Matrix m = (Matrix) ois.readObject();
+			this.setM(m);
+		}	
 	}
 
 	/**
@@ -113,8 +115,9 @@ public class Graph {
 	}
 
 	public void save(String path) throws IOException {
-		ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(path));
-		out.writeObject(M);
-		out.close();
+		try (FileOutputStream fos = new FileOutputStream(path);
+			 ObjectOutputStream out = new ObjectOutputStream(fos)) {
+			out.writeObject(M);
+		}
 	}
 }

--- a/src/libai/ants/Node.java
+++ b/src/libai/ants/Node.java
@@ -65,6 +65,7 @@ public class Node implements Comparable<Node> {
 	 *
 	 * @param n another node object
 	 */
+	@Override
 	public int compareTo(Node n) {
 		if (this.distance == n.distance) {
 			return 0;

--- a/src/libai/ants/algorithms/AntColonySystem.java
+++ b/src/libai/ants/algorithms/AntColonySystem.java
@@ -88,6 +88,7 @@ public abstract class AntColonySystem extends Metaheuristic {
 	protected AntColonySystem() {
 	}
 
+	@Override
 	public void checkParameters() throws AntFrameworkException {
 		/* check mandatory parameters */
 		if (!this.Parameters.containsKey(AntColonySystem.initialNode)) {
@@ -125,9 +126,11 @@ public abstract class AntColonySystem extends Metaheuristic {
 		}
 	}
 
+	@Override
 	public void daemonActions() {
 	}
 
+	@Override
 	public void solve() throws AntFrameworkException {
 		/* Check parameters to ensure that we have all we need before proceding */
 		checkParameters();
@@ -223,6 +226,7 @@ public abstract class AntColonySystem extends Metaheuristic {
 		this.Pheromones.position(i, j, ((1 - localRo2) * this.Pheromones.position(i, j)) + (localRo2 * localTau0));
 	}
 
+	@Override
 	public void pheromonesUpdate() {
 		/* Update pheromones only on the best tour so far */
 		//System.out.println("pheromonesUpdate of the best tour = "+this.bestSolution );
@@ -234,10 +238,12 @@ public abstract class AntColonySystem extends Metaheuristic {
 		}
 	}
 
+	@Override
 	public final void pheromonesEvaporation() {
 		this.Pheromones.multiply(1 - this.Parameters.get(AntColonySystem.ro_1), this.Pheromones);
 	}
 
+	@Override
 	public int decisionRule(int i, Vector<Integer> currentSolution) {
 		double localR_0 = this.Parameters.get(AntColonySystem.r_0);
 		int nodeJ = -1;

--- a/src/libai/ants/algorithms/AntSystem.java
+++ b/src/libai/ants/algorithms/AntSystem.java
@@ -69,6 +69,7 @@ public abstract class AntSystem extends Metaheuristic {
 	}
 
 	/* Standard methods*/
+	@Override
 	public void checkParameters() throws AntFrameworkException {
 		/* check obligatory parameters */
 		if (!this.Parameters.containsKey(AntSystem.initialNode)) {
@@ -96,6 +97,7 @@ public abstract class AntSystem extends Metaheuristic {
 
 	}
 
+	@Override
 	public void solve() throws AntFrameworkException {
 		/* Check parameters to ensure that we have all we need before proceding */
 		checkParameters();
@@ -167,9 +169,11 @@ public abstract class AntSystem extends Metaheuristic {
 		}
 	}
 
+	@Override
 	public void daemonActions() {
 	}
 
+	@Override
 	public void pheromonesUpdate() {
 		double deltaTau_ij;
 
@@ -187,10 +191,12 @@ public abstract class AntSystem extends Metaheuristic {
 		}
 	}
 
+	@Override
 	public void pheromonesEvaporation() {
 		this.Pheromones.multiply(this.Parameters.get(AntSystem.pheromonesEvaporationRate), this.Pheromones);
 	}
 
+	@Override
 	public int decisionRule(int i, Vector<Integer> currentSolution) {
 		/* counter of the number of times a node have been triying to selected a next node and maximun number of tries allowed*/
 		int counter = 0, allowedNumberOfTries = 2 * this.getNumberOfNodes();
@@ -228,6 +234,7 @@ public abstract class AntSystem extends Metaheuristic {
 		} while (true);
 	}
 
+	@Override
 	public final void candidateList(int max) {
 	}
 

--- a/src/libai/ants/algorithms/MMAS.java
+++ b/src/libai/ants/algorithms/MMAS.java
@@ -78,6 +78,7 @@ abstract public class MMAS extends Metaheuristic {
 	protected MMAS() {
 	}
 
+	@Override
 	public void checkParameters() throws AntFrameworkException {
 		/* check obligatory parameters */
 		if (!this.Parameters.containsKey(MMAS.initialNode)) {
@@ -135,6 +136,7 @@ abstract public class MMAS extends Metaheuristic {
 		return false;
 	}
 
+	@Override
 	public int decisionRule(int i, Vector<Integer> currentSolution) {
 		/* counter of the number of times a node have been triying to selected a next node and maximun number of tries allowed*/
 		int counter = 0, allowedNumberOfTries = 2 * this.getNumberOfNodes();
@@ -172,6 +174,7 @@ abstract public class MMAS extends Metaheuristic {
 		} while (true);
 	}
 
+	@Override
 	public void pheromonesUpdate() {
 		/* Update pheromones only on the best tour so far */
 		//System.out.println("pheromonesUpdate of the best tour = "+this.bestSolution );
@@ -183,10 +186,12 @@ abstract public class MMAS extends Metaheuristic {
 		}
 	}
 
+	@Override
 	public final void pheromonesEvaporation() {
 		this.Pheromones.multiply(this.Parameters.get(MMAS.pheromonesEvaporationRate), this.Pheromones);
 	}
 
+	@Override
 	public void solve() throws AntFrameworkException {
 		/* Check parameters to ensure that we have all we need before proceding */
 		this.checkParameters();
@@ -285,9 +290,11 @@ abstract public class MMAS extends Metaheuristic {
 		}
 	}
 
+	@Override
 	public void daemonActions() {
 	}
 
+	@Override
 	public final void candidateList(int i) {
 	}
 }

--- a/src/libai/ants/algorithms/Metaheuristic.java
+++ b/src/libai/ants/algorithms/Metaheuristic.java
@@ -53,15 +53,15 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	/**
 	 * Hashtable that holds the parameters
 	 */
-	protected Hashtable<Integer, Double> Parameters = new Hashtable<Integer, Double>();
+	protected Hashtable<Integer, Double> Parameters = new Hashtable<>();
 	/**
 	 * Vector that holds the global best solution found
 	 */
-	protected Vector<Integer> bestSolution = new Vector<Integer>();
+	protected Vector<Integer> bestSolution = new Vector<>();
 	/**
 	 * Vector that holds the candidate list
 	 */
-	protected Hashtable<Integer, Vector<Node>> candidates = new Hashtable<Integer, Vector<Node>>();
+	protected Hashtable<Integer, Vector<Node>> candidates = new Hashtable<>();
 	/**
 	 * current iteration number
 	 */

--- a/src/libai/ants/algorithms/Metaheuristic.java
+++ b/src/libai/ants/algorithms/Metaheuristic.java
@@ -306,6 +306,7 @@ abstract public class Metaheuristic implements Comparator<Ant> {
 	 * @return 0 if solution of ant_1 = solution of ant_2, 1 if solution of
 	 * ant_1 greater than solution of ant_2 and -1 otherwise
 	 */
+	@Override
 	public int compare(Ant o1, Ant o2) {
 		//compare solutions
 		Vector<Integer> sol1 = o1.getSolution(), sol2 = o2.getSolution();

--- a/src/libai/classifiers/bayes/NaiveBayes.java
+++ b/src/libai/classifiers/bayes/NaiveBayes.java
@@ -63,7 +63,7 @@ public class NaiveBayes {
 			params.put(c, new Object[attributeCount]);
 			for (int j = 0; j < attributeCount; j++) {
 				if (j == outputIndex) {
-					params.get(c)[j] = (Integer) 0;
+					params.get(c)[j] = 0;
 				} else if (metadata.isCategorical(j)) {
 					params.get(c)[j] = new HashMap<>(); //value, count
 				} else {
@@ -113,9 +113,9 @@ public class NaiveBayes {
 					double mean = acum.first;
 					double length = (double) ((Integer) data[outputIndex]);
 
-					sd = (sd - ((mean * mean) / (double) length));
-					acum.second = sd / (double) (length - 1);
-					acum.first = mean / (double) length;
+					sd = (sd - ((mean * mean) / length));
+					acum.second = sd / (length - 1);
+					acum.first = mean / length;
 				}
 			}
 		}

--- a/src/libai/classifiers/bayes/NaiveBayes.java
+++ b/src/libai/classifiers/bayes/NaiveBayes.java
@@ -63,7 +63,7 @@ public class NaiveBayes {
 			params.put(c, new Object[attributeCount]);
 			for (int j = 0; j < attributeCount; j++) {
 				if (j == outputIndex) {
-					params.get(c)[j] = 0;
+					params.get(c)[j] = (Integer) 0;
 				} else if (metadata.isCategorical(j)) {
 					params.get(c)[j] = new HashMap<>(); //value, count
 				} else {
@@ -113,9 +113,9 @@ public class NaiveBayes {
 					double mean = acum.first;
 					double length = (double) ((Integer) data[outputIndex]);
 
-					sd = (sd - ((mean * mean) / length));
-					acum.second = sd / (length - 1);
-					acum.first = mean / length;
+					sd = (sd - ((mean * mean) / (double) length));
+					acum.second = sd / (double) (length - 1);
+					acum.first = mean / (double) length;
 				}
 			}
 		}

--- a/src/libai/classifiers/bayes/NaiveBayes.java
+++ b/src/libai/classifiers/bayes/NaiveBayes.java
@@ -50,7 +50,7 @@ public class NaiveBayes {
 		totalCount = ds.getItemsCount();
         metadata = ds.getMetaData();
 		
-		params = new HashMap<Attribute, Object[]>();
+		params = new HashMap<>();
 		initialize(ds);
 		precalculate(ds);
 
@@ -65,9 +65,9 @@ public class NaiveBayes {
 				if (j == outputIndex) {
 					params.get(c)[j] = (Integer) 0;
 				} else if (metadata.isCategorical(j)) {
-					params.get(c)[j] = new HashMap<String, Integer>(); //value, count
+					params.get(c)[j] = new HashMap<>(); //value, count
 				} else {
-					params.get(c)[j] = new Pair<Double, Double>(0.0, 0.0);//mean, sd
+					params.get(c)[j] = new Pair<>(0.0, 0.0);//mean, sd
 				}
 			}
 		}
@@ -244,7 +244,7 @@ public class NaiveBayes {
 	private NaiveBayes load(Node root) {
 		outputIndex = Integer.parseInt(root.getAttributes().getNamedItem("outputIndex").getTextContent());
 		totalCount = Integer.parseInt(root.getAttributes().getNamedItem("totalCount").getTextContent());
-		params = new HashMap<Attribute, Object[]>();
+		params = new HashMap<>();
         int attributeCount = Integer.parseInt(root.getAttributes().getNamedItem("attributes").getTextContent());
 		
 		NodeList children = root.getChildNodes();
@@ -275,7 +275,7 @@ public class NaiveBayes {
 	
 	private Object getParams(Node root){
 		NodeList children = root.getChildNodes();
-		HashMap<String,Integer> freq = new HashMap<String,Integer>();
+		HashMap<String,Integer> freq = new HashMap<>();
 		for(int i=0;i<children.getLength();i++){
 			Node current = children.item(i);
 			if(current.getNodeName().equals("count"))
@@ -283,7 +283,7 @@ public class NaiveBayes {
 			else if(current.getNodeName().equals("stats")){
 				double mean = Double.parseDouble(current.getAttributes().getNamedItem("mean").getTextContent());
 				double sd = Double.parseDouble(current.getAttributes().getNamedItem("sd").getTextContent());
-				return new Pair<Double,Double>(mean,sd);
+				return new Pair<>(mean,sd);
 			}else if(current.getNodeName().equals("item")){
 				int count = Integer.parseInt(current.getAttributes().getNamedItem("count").getTextContent());
 				String key = current.getTextContent();

--- a/src/libai/classifiers/bayes/NaiveBayes.java
+++ b/src/libai/classifiers/bayes/NaiveBayes.java
@@ -198,8 +198,8 @@ public class NaiveBayes {
 
 	//IO functions
 	public boolean save(File path) {
-		try {
-			PrintStream out = new PrintStream(new FileOutputStream(path));
+		try (FileOutputStream fos = new FileOutputStream(path);
+			 PrintStream out = new PrintStream(fos)){
 			out.println("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 			out.println("<" + getClass().getSimpleName() + " "
 					+ "outputIndex=\""+outputIndex+"\" "
@@ -207,7 +207,6 @@ public class NaiveBayes {
 					+ "attributes=\""+metadata.getAttributeCount()+"\">");
 			save(out, "\t");
 			out.println("</" + getClass().getSimpleName() + ">");
-			out.close();
 			//safe format into a XML file.
 			return true;
 		} catch (Exception e) {

--- a/src/libai/classifiers/dataset/DataSet.java
+++ b/src/libai/classifiers/dataset/DataSet.java
@@ -25,7 +25,6 @@ package libai.classifiers.dataset;
 
 import java.util.*;
 import libai.classifiers.Attribute;
-import libai.classifiers.Attribute;
 
 /**
  * DataSet is a container compound by examples. Each example (or DataRecord) is

--- a/src/libai/classifiers/dataset/MySQLDataSet.java
+++ b/src/libai/classifiers/dataset/MySQLDataSet.java
@@ -40,7 +40,7 @@ public class MySQLDataSet implements DataSet {
     private int orderBy;
     private Connection connection;
     private ResultSetMetaData rsMetaData;
-    private Set<Attribute> classes = new HashSet<Attribute>();
+    private Set<Attribute> classes = new HashSet<>();
     private HashMap<Triplet<Integer, Integer, Integer>, HashMap<Attribute, Integer>> cacheFrequencies;
     private HashMap<Triplet<Integer, Integer, Integer>, HashMap<Double, HashMap<Attribute, Integer>>> cacheAccumulatedFrequencies;
 
@@ -84,8 +84,8 @@ public class MySQLDataSet implements DataSet {
     private MySQLDataSet(int output) {
         outputIndex = output;
         orderBy = output;
-        cacheFrequencies = new HashMap<Triplet<Integer, Integer, Integer>, HashMap<Attribute, Integer>>();
-        cacheAccumulatedFrequencies = new HashMap<Triplet<Integer, Integer, Integer>, HashMap<Double, HashMap<Attribute, Integer>>>();
+        cacheFrequencies = new HashMap<>();
+        cacheAccumulatedFrequencies = new HashMap<>();
     }
 
     private MySQLDataSet(MySQLDataSet parent, int lo, int hi) {
@@ -300,7 +300,7 @@ public class MySQLDataSet implements DataSet {
                 try {
                     if (rs.next()) {
                         size--;
-                        List<Attribute> record = new ArrayList<Attribute>();
+                        List<Attribute> record = new ArrayList<>();
                         for (int i = 0; i < metadata.getAttributeCount(); i++) {
                             String fieldName = metadata.getAttributeName(i);
                             record.add(Attribute.getInstance(rs.getString(fieldName), fieldName));
@@ -361,14 +361,14 @@ public class MySQLDataSet implements DataSet {
 
     @Override
     public HashMap<Attribute, Integer> getFrequencies(int lo, int hi, int fieldIndex) {
-        Triplet<Integer, Integer, Integer> key = new Triplet<Integer, Integer, Integer>(lo, hi, fieldIndex);
+        Triplet<Integer, Integer, Integer> key = new Triplet<>(lo, hi, fieldIndex);
         if (cacheFrequencies.get(key) != null)
             return cacheFrequencies.get(key);
 
         if (!metadata.isCategorical(fieldIndex))
             throw new IllegalArgumentException("The attribute must be discrete");
 
-        HashMap<Attribute, Integer> freq = new HashMap<Attribute, Integer>();
+        HashMap<Attribute, Integer> freq = new HashMap<>();
 
         String fieldName = metadata.getAttributeName(fieldIndex);
         String query = String.format("SELECT `%s`, count(*) as count FROM (SELECT `%s` FROM `%s` ORDER BY `%s`,`%s` LIMIT %d,%d) as tmp GROUP BY `%s`",

--- a/src/libai/classifiers/dataset/MySQLDataSet.java
+++ b/src/libai/classifiers/dataset/MySQLDataSet.java
@@ -389,6 +389,7 @@ public class MySQLDataSet implements DataSet {
         return freq;
     }
 
+	@Override
     public String toString() {
         Iterable<List<Attribute>> r = sortOver(orderBy);
         StringBuffer str = new StringBuffer();

--- a/src/libai/classifiers/dataset/MySQLDataSet.java
+++ b/src/libai/classifiers/dataset/MySQLDataSet.java
@@ -392,7 +392,7 @@ public class MySQLDataSet implements DataSet {
 	@Override
     public String toString() {
         Iterable<List<Attribute>> r = sortOver(orderBy);
-        StringBuffer str = new StringBuffer();
+        StringBuilder str = new StringBuilder();
         for (List<Attribute> l : r)
             str.append(l.toString()).append("\n");
         return str.toString();

--- a/src/libai/classifiers/dataset/TextFileDataSet.java
+++ b/src/libai/classifiers/dataset/TextFileDataSet.java
@@ -35,8 +35,8 @@ import libai.common.*;
  * @author kronenthaler
  */
 public class TextFileDataSet implements DataSet {
-    private List<List<Attribute>> data = new ArrayList<List<Attribute>>();
-    private Set<Attribute> classes = new HashSet<Attribute>();
+    private List<List<Attribute>> data = new ArrayList<>();
+    private Set<Attribute> classes = new HashSet<>();
     private int outputIndex;
     private int orderBy;
     private HashMap<Triplet<Integer, Integer, Integer>, HashMap<Attribute, Integer>> cache;
@@ -66,7 +66,7 @@ public class TextFileDataSet implements DataSet {
     TextFileDataSet(int output) {
         outputIndex = output;
         orderBy = outputIndex;
-        cache = new HashMap<Triplet<Integer, Integer, Integer>, HashMap<Attribute, Integer>>();
+        cache = new HashMap<>();
     }
 
     private TextFileDataSet(TextFileDataSet parent, int lo, int hi) {
@@ -83,7 +83,7 @@ public class TextFileDataSet implements DataSet {
                 if (line == null)
                     break;
                 String[] tokens = line.split(",");
-                ArrayList<Attribute> record = new ArrayList<Attribute>();
+                ArrayList<Attribute> record = new ArrayList<>();
                 for (int i = 0; i < tokens.length; i++) {
                     String token = tokens[i];
                     Attribute attr = Attribute.getInstance(token, metadata.getAttributeName(i));
@@ -146,7 +146,7 @@ public class TextFileDataSet implements DataSet {
 
         Iterable<List<Attribute>> sortedData = sortOver(outputIndex);
         Attribute prev = null;
-        List<List<Attribute>> buffer = new ArrayList<List<Attribute>>();
+        List<List<Attribute>> buffer = new ArrayList<>();
         for (List<Attribute> record : sortedData) {
             if ((prev != null && prev.compareTo(record.get(outputIndex)) != 0)) {
                 Collections.shuffle(buffer);
@@ -195,7 +195,7 @@ public class TextFileDataSet implements DataSet {
 
     @Override
     public Attribute allTheSame() {
-        HashMap<String, Integer> freq = new HashMap<String, Integer>();
+        HashMap<String, Integer> freq = new HashMap<>();
 
         for (int i = 0; i < data.size(); i++) {
             for (int j = 0, n = metadata.getAttributeCount(); j < n; j++) {
@@ -227,7 +227,7 @@ public class TextFileDataSet implements DataSet {
 
     @Override
     public HashMap<Attribute, Integer> getFrequencies(int lo, int hi, int fieldIndex) {
-        Triplet<Integer, Integer, Integer> key = new Triplet<Integer, Integer, Integer>(lo, hi, fieldIndex);
+        Triplet<Integer, Integer, Integer> key = new Triplet<>(lo, hi, fieldIndex);
 
         if (cache.get(key) != null)
             return cache.get(key);
@@ -235,7 +235,7 @@ public class TextFileDataSet implements DataSet {
         if (!metadata.isCategorical(fieldIndex))
             throw new IllegalArgumentException("The attribute must be discrete");
 
-        HashMap<Attribute, Integer> freq = new HashMap<Attribute, Integer>();
+        HashMap<Attribute, Integer> freq = new HashMap<>();
         for (int i = lo; i < hi; i++) {
             List<Attribute> record = data.get(i);
             Attribute v = record.get(fieldIndex);

--- a/src/libai/classifiers/dataset/TextFileDataSet.java
+++ b/src/libai/classifiers/dataset/TextFileDataSet.java
@@ -176,7 +176,7 @@ public class TextFileDataSet implements DataSet {
 
     @Override
     public String toString() {
-        StringBuffer str = new StringBuffer();
+        StringBuilder str = new StringBuilder();
         for (List<Attribute> r : sortOver(orderBy))
             str.append(r.toString()).append('\n');
         return str.toString();

--- a/src/libai/classifiers/dataset/TextFileDataSet.java
+++ b/src/libai/classifiers/dataset/TextFileDataSet.java
@@ -76,8 +76,8 @@ public class TextFileDataSet implements DataSet {
 
     public TextFileDataSet(File dataSource, int output) {
         this(output);
-        try {
-            BufferedReader in = new BufferedReader(new FileReader(dataSource));
+        try (FileReader fr = new FileReader(dataSource);
+             BufferedReader in = new BufferedReader(fr)){
             while (true) {
                 String line = in.readLine();
                 if (line == null)
@@ -93,7 +93,6 @@ public class TextFileDataSet implements DataSet {
                 }
                 data.add(record);
             }
-            in.close();
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/libai/classifiers/trees/C45.java
+++ b/src/libai/classifiers/trees/C45.java
@@ -50,7 +50,7 @@ public class C45 implements Comparable<C45> {
     //Laplace's error pruning
     protected int mostCommonLeafFreq = Integer.MIN_VALUE;
     protected int samplesCount; //how many samples pass for this node in the pruning process.
-    protected HashMap<Attribute, Integer> samplesFreq = new HashMap<Attribute, Integer>(); //used to the pruning process.
+    protected HashMap<Attribute, Integer> samplesFreq = new HashMap<>(); //used to the pruning process.
     //Quinlan's prunning using confidence
     protected double confidence = 0.25;
     protected double z;
@@ -211,7 +211,7 @@ public class C45 implements Comparable<C45> {
     }
 
     public C45 train(DataSet ds) {
-        HashSet<Integer> visited = new HashSet<Integer>();
+        HashSet<Integer> visited = new HashSet<>();
         visited.add(ds.getOutputIndex());
         return train(ds, visited, "");
     }
@@ -255,7 +255,7 @@ public class C45 implements Comparable<C45> {
         }
 
         Iterable<List<Attribute>> sortedRecords = ds.sortOver(index);
-        ArrayList<Pair<Attribute, C45>> children = new ArrayList<Pair<Attribute, C45>>();
+        ArrayList<Pair<Attribute, C45>> children = new ArrayList<>();
         if (metadata.isCategorical(index)) {
             visited.add(index); //mark as ready, avoid revisiting a nominal attribute.
 
@@ -278,8 +278,7 @@ public class C45 implements Comparable<C45> {
                 i++;
                 
                 DataSet section = ds.getSubset(nlo, i);
-                children.add(new Pair<Attribute, C45>(prev,
-                        train(section, visited, deep + "\t")));
+                children.add(new Pair<>(prev, train(section, visited, deep + "\t")));
                 section.close();
                 
                 prev = current;
@@ -291,10 +290,10 @@ public class C45 implements Comparable<C45> {
             String fieldName = ds.getMetaData().getAttributeName(index);
 
             C45 left = train(l, visited, deep + "\t");
-            children.add(new Pair<Attribute, C45>(Attribute.getInstance(splitValue, fieldName), left));
+            children.add(new Pair<>(Attribute.getInstance(splitValue, fieldName), left));
 
             C45 right = train(r, visited, deep + "\t");
-            children.add(new Pair<Attribute, C45>(Attribute.getInstance(splitValue, fieldName), right));
+            children.add(new Pair<>(Attribute.getInstance(splitValue, fieldName), right));
             
             l.close();
             r.close();
@@ -470,7 +469,7 @@ public class C45 implements Comparable<C45> {
         DataSet aux = ds.getSubset(lo, hi);
 
         List<Attribute> prev = null;
-        HashMap<Double, HashMap<Attribute, Integer>> freqAcum = new HashMap<Double, HashMap<Attribute, Integer>>();
+        HashMap<Double, HashMap<Attribute, Integer>> freqAcum = new HashMap<>();
 
         for (List<Attribute> record : records) {
             double va = ((ContinuousAttribute) record.get(fieldIndex)).getValue();
@@ -639,7 +638,7 @@ public class C45 implements Comparable<C45> {
                         if ((current = aux.item(i)).getNodeName().equals("leaf")
                                 || current.getNodeName().equals("node"))
                             break;
-                    childs[currentChild++] = new Pair<Attribute, C45>(att, load(current));
+                    childs[currentChild++] = new Pair<>(att, load(current));
                 }
             }
             return new C45(childs);

--- a/src/libai/classifiers/trees/C45.java
+++ b/src/libai/classifiers/trees/C45.java
@@ -650,8 +650,8 @@ public class C45 implements Comparable<C45> {
     }
 
     public boolean save(File path) {
-        try {
-            PrintStream out = new PrintStream(new FileOutputStream(path));
+		try (FileOutputStream fos = new FileOutputStream(path);
+			 PrintStream out = new PrintStream(fos)){
             out.println("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
             out.println("<" + getClass().getSimpleName() + ">");
             save(out, "\t");

--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -39,6 +39,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author kronenthaler
  */
 public final class Matrix implements Serializable {
+	private static final long serialVersionUID = 4152602945322905714L;
+	
 	/**
 	 * Matrix's data, stored for row in a sequential array.
 	 */

--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -578,6 +578,15 @@ public final class Matrix implements Serializable {
 		return true;
 	}
 
+	@Override
+	public int hashCode() {
+		int hash = 7;
+		hash = 73 * hash + Arrays.hashCode(this.matrix);
+		hash = 73 * hash + this.rows;
+		hash = 73 * hash + this.cols;
+		return hash;
+	}
+
 	/**
 	 * Return the string representation of this matrix. Useful to write on a
 	 * file or for debugging.

--- a/src/libai/common/Matrix.java
+++ b/src/libai/common/Matrix.java
@@ -556,13 +556,25 @@ public final class Matrix implements Serializable {
 	 */
 	@Override
 	public boolean equals(Object b1) {
+		if (this == b1) {
+		    return true;
+		}
+		if (b1 == null) {
+		    return false;
+		}
+		if (getClass() != b1.getClass()) {
+		    return false;
+		}
+        
 		Matrix b = (Matrix) b1;
 		if (rows != b.rows || cols != b.cols)
 			return false;
 
-		for (int i = 0, n = rows * cols; i < n; i++)
-			if (Math.abs(matrix[i] - b.matrix[i]) > 1.e-7) //'equals'
+		for (int i = 0, n = rows * cols; i < n; i++) {
+			if (Math.abs(matrix[i] - b.matrix[i]) > 1.e-7) { //'equals'
 				return false;
+			}
+		}
 		return true;
 	}
 

--- a/src/libai/common/Pair.java
+++ b/src/libai/common/Pair.java
@@ -58,10 +58,12 @@ public final class Pair<V extends Comparable, K extends Comparable> implements C
 	 * @return -1 if this is less than o, 0 if are equals, 1 if this is greater
 	 * than o.
 	 */
+	@Override
 	public int compareTo(Pair o) {
 		return first.compareTo(o.first);
 	}
 
+	@Override
 	public String toString() {
 		return "(" + first + "," + second + ")";
 	}

--- a/src/libai/common/Plotter.java
+++ b/src/libai/common/Plotter.java
@@ -23,10 +23,7 @@
  */
 package libai.common;
 
-import java.util.*;
-
-import java.awt.*;
-import javax.swing.*;
+import java.awt.Graphics;
 
 /**
  *

--- a/src/libai/common/Triplet.java
+++ b/src/libai/common/Triplet.java
@@ -64,6 +64,7 @@ public final class Triplet <V extends Comparable, K extends Comparable, Z extend
 		return b;
 	}
 	
+	@Override
 	public boolean equals(Object o){
 		if (o == null || !(o instanceof Triplet)) 
 			return false;
@@ -74,6 +75,7 @@ public final class Triplet <V extends Comparable, K extends Comparable, Z extend
 				&& third.equals(b.third);
 	}
 
+	@Override
 	public String toString() {
 		return "(" + first + "," + second + "," + third + ")";
 	}

--- a/src/libai/common/functions/ArcTangent.java
+++ b/src/libai/common/functions/ArcTangent.java
@@ -34,6 +34,8 @@ package libai.common.functions;
  * @author Federico Vera {@literal <fedevera at unc.edu.ar>}
  */
 public class ArcTangent implements Function {
+	private static final long serialVersionUID = 1967026062364806506L;
+	
 	private static final Function derivate = new Function() {
 		@Override
 		public double eval(double x) {

--- a/src/libai/common/functions/Gaussian.java
+++ b/src/libai/common/functions/Gaussian.java
@@ -33,6 +33,8 @@ package libai.common.functions;
  * @author Federico Vera {@literal <fedevera at unc.edu.ar>}
  */
 public class Gaussian implements Function {
+	private static final long serialVersionUID = 8592095509162668948L;
+	
 	private static final Function derivate = new Function() {
 		@Override
 		public double eval(double x) {

--- a/src/libai/common/functions/HyperbolicTangent.java
+++ b/src/libai/common/functions/HyperbolicTangent.java
@@ -30,6 +30,8 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class HyperbolicTangent implements Function {
+	private static final long serialVersionUID = 452564541626561512L;
+	
 	private static final Function derivate = new Function() {
 		@Override
 		public double eval(double x) {

--- a/src/libai/common/functions/Identity.java
+++ b/src/libai/common/functions/Identity.java
@@ -29,6 +29,8 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class Identity implements Function {
+	private static final long serialVersionUID = 6331460636579541011L;
+	
 	private static final Function derivate = new Function() {
 		@Override
 		public double eval(double x) {

--- a/src/libai/common/functions/Sigmoid.java
+++ b/src/libai/common/functions/Sigmoid.java
@@ -30,6 +30,8 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class Sigmoid implements Function {
+	private static final long serialVersionUID = 910726042653348547L;
+	
 	private static final Function derivate = new Function() {
 		@Override
 		public double eval(double x) {

--- a/src/libai/common/functions/Sign.java
+++ b/src/libai/common/functions/Sign.java
@@ -30,10 +30,12 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class Sign implements Function {
+	@Override
 	public double eval(double x) {
 		return x > 0 ? 1 : 0;
 	}
 
+	@Override
 	public Function getDerivate() {
 		return null;
 	}

--- a/src/libai/common/functions/Sign.java
+++ b/src/libai/common/functions/Sign.java
@@ -30,6 +30,8 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class Sign implements Function {
+	private static final long serialVersionUID = 1166867398304665624L;
+	
 	@Override
 	public double eval(double x) {
 		return x > 0 ? 1 : 0;

--- a/src/libai/common/functions/Sinc.java
+++ b/src/libai/common/functions/Sinc.java
@@ -36,6 +36,8 @@ package libai.common.functions;
  * @author Federico Vera {@literal <fedevera at unc.edu.ar>}
  */
 public class Sinc implements Function {
+	private static final long serialVersionUID = 5841748521168749702L;
+	
 	private static final Function derivate = new Function() {
 		@Override
 		public double eval(double x) {

--- a/src/libai/common/functions/SymmetricSign.java
+++ b/src/libai/common/functions/SymmetricSign.java
@@ -30,10 +30,12 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class SymmetricSign implements Function {
+	@Override
 	public double eval(double x) {
 		return x < 0 ? -1 : 1;
 	}
 
+	@Override
 	public Function getDerivate() {
 		return null;
 	}

--- a/src/libai/common/functions/SymmetricSign.java
+++ b/src/libai/common/functions/SymmetricSign.java
@@ -30,6 +30,8 @@ package libai.common.functions;
  * @author kronenthaler
  */
 public class SymmetricSign implements Function {
+	private static final long serialVersionUID = 3125748303856269229L;
+	
 	@Override
 	public double eval(double x) {
 		return x < 0 ? -1 : 1;

--- a/src/libai/common/kernels/GaussianKernel.java
+++ b/src/libai/common/kernels/GaussianKernel.java
@@ -37,6 +37,7 @@ public class GaussianKernel implements Kernel {
 		sigma = _sigma * _sigma * 2;
 	}
 
+	@Override
 	public double eval(Matrix A, Matrix B) {
 		double AB = A.dotProduct(B);
 		double AA = A.dotProduct(A);
@@ -46,6 +47,7 @@ public class GaussianKernel implements Kernel {
 		return Math.exp((-s / sigma));
 	}
 
+	@Override
 	public double eval(double dotProduct) {
 		throw new UnsupportedOperationException("Not supported yet.");
 	}

--- a/src/libai/common/kernels/GaussianKernel.java
+++ b/src/libai/common/kernels/GaussianKernel.java
@@ -31,6 +31,8 @@ import libai.common.Matrix;
  * @author kronenthaler
  */
 public class GaussianKernel implements Kernel {
+	private static final long serialVersionUID = 7002651958563140173L;
+	
 	private double sigma;
 
 	public GaussianKernel(double _sigma) {

--- a/src/libai/common/kernels/LinearKernel.java
+++ b/src/libai/common/kernels/LinearKernel.java
@@ -31,10 +31,12 @@ import libai.common.Matrix;
  * @author kronenthaler
  */
 public class LinearKernel implements Kernel {
+	@Override
 	public double eval(Matrix A, Matrix B) {
 		return A.dotProduct(B);
 	}
 
+	@Override
 	public double eval(double dotProduct) {
 		return dotProduct;
 	}

--- a/src/libai/common/kernels/LinearKernel.java
+++ b/src/libai/common/kernels/LinearKernel.java
@@ -31,6 +31,8 @@ import libai.common.Matrix;
  * @author kronenthaler
  */
 public class LinearKernel implements Kernel {
+	private static final long serialVersionUID = 1077977714890090768L;
+	
 	@Override
 	public double eval(Matrix A, Matrix B) {
 		return A.dotProduct(B);

--- a/src/libai/common/kernels/PolynomialKernel.java
+++ b/src/libai/common/kernels/PolynomialKernel.java
@@ -37,10 +37,12 @@ public class PolynomialKernel implements Kernel {
 		b = _b;
 	}
 
+	@Override
 	public double eval(Matrix A, Matrix B) {
 		return Math.pow(A.dotProduct(B) - a, b);
 	}
 
+	@Override
 	public double eval(double dotProduct) {
 		throw new UnsupportedOperationException("Not supported yet.");
 	}

--- a/src/libai/common/kernels/PolynomialKernel.java
+++ b/src/libai/common/kernels/PolynomialKernel.java
@@ -30,6 +30,8 @@ import libai.common.Matrix;
  * @author kronenthaler
  */
 public class PolynomialKernel implements Kernel {
+	private static final long serialVersionUID = 5132845207274843125L;
+	
 	private double a, b;
 
 	public PolynomialKernel(double _a, double _b) {

--- a/src/libai/common/kernels/SigmoidalKernel.java
+++ b/src/libai/common/kernels/SigmoidalKernel.java
@@ -30,6 +30,8 @@ import libai.common.Matrix;
  * @author kronenthaler
  */
 public class SigmoidalKernel implements Kernel {
+	private static final long serialVersionUID = 5132845207274843125L;
+	
 	private double a, b;
 
 	public SigmoidalKernel(double _a, double _b) {

--- a/src/libai/common/kernels/SigmoidalKernel.java
+++ b/src/libai/common/kernels/SigmoidalKernel.java
@@ -37,10 +37,12 @@ public class SigmoidalKernel implements Kernel {
 		b = _b;
 	}
 
+	@Override
 	public double eval(Matrix A, Matrix B) {
 		return Math.tanh(a * A.dotProduct(B) - b);
 	}
 
+	@Override
 	public double eval(double dotProduct) {
 		return Math.tanh(a * dotProduct - b);
 	}

--- a/src/libai/fuzzy/Engine.java
+++ b/src/libai/fuzzy/Engine.java
@@ -52,8 +52,8 @@ public class Engine {
 	private boolean debug = false;
 
 	public Engine() {
-		rules = new ArrayList<Rule>();
-		groups = new ArrayList<FuzzyGroup>();
+		rules = new ArrayList<>();
+		groups = new ArrayList<>();
 	}
 
 	/**
@@ -138,7 +138,7 @@ public class Engine {
 			}
 
 			if (allResults == null) {
-				allResults = new HashMap<FuzzyGroup, ArrayList<Pair<Double, Double>>>();
+				allResults = new HashMap<>();
 
 				for (int i = 0; i < fireResult.length; i++) {
 					allResults.put(find(r.getAction(i)), fireResult[i]);

--- a/src/libai/fuzzy/FuzzyGroup.java
+++ b/src/libai/fuzzy/FuzzyGroup.java
@@ -57,7 +57,7 @@ public class FuzzyGroup {
 	 */
 	public FuzzyGroup(FuzzySet... mems) {
 		v = new Variable(0);
-		members = new HashSet<FuzzySet>();
+		members = new HashSet<>();
 
 		for (FuzzySet m : mems)
 			members.add(m);

--- a/src/libai/fuzzy/Rule.java
+++ b/src/libai/fuzzy/Rule.java
@@ -57,7 +57,7 @@ public class Rule {
 	 */
 	public Rule(Condition _cond, FuzzySet... acts) {
 		cond = _cond;
-		actions = new ArrayList<FuzzySet>();
+		actions = new ArrayList<>();
 		for (FuzzySet a : acts)
 			actions.add(a);
 	}
@@ -76,11 +76,11 @@ public class Rule {
 		double tau = cond.eval();
 		int i = 0;
 		for (FuzzySet set : actions) {
-			ret[i] = new ArrayList<Pair<Double, Double>>();
+			ret[i] = new ArrayList<>();
 			ArrayList<Double> support = set.getSupport();
 
 			for (Double d : support)
-				ret[i].add(new Pair<Double, Double>(d, set.eval(d) * tau));
+				ret[i].add(new Pair<>(d, set.eval(d) * tau));
 
 			i++;
 		}

--- a/src/libai/fuzzy/Variable.java
+++ b/src/libai/fuzzy/Variable.java
@@ -70,6 +70,7 @@ public class Variable implements Comparable<Variable> {
 	 * @return -1 if this is less than o, 0 if they are equal, 1 if this is
 	 * grater than o
 	 */
+	@Override
 	public int compareTo(Variable o) {
 		return (int) (value - o.value);
 	}

--- a/src/libai/fuzzy/sets/Singleton.java
+++ b/src/libai/fuzzy/sets/Singleton.java
@@ -38,7 +38,7 @@ public class Singleton implements FuzzySet {
 
 	public Singleton(Variable _p) {
 		p = _p;
-		support = new ArrayList<Double>();
+		support = new ArrayList<>();
 		support.add(p.getValue());
 	}
 

--- a/src/libai/fuzzy/sets/Singleton.java
+++ b/src/libai/fuzzy/sets/Singleton.java
@@ -42,22 +42,27 @@ public class Singleton implements FuzzySet {
 		support.add(p.getValue());
 	}
 
+	@Override
 	public double eval(Variable s) {
 		return eval(s.getValue());
 	}
 
+	@Override
 	public double eval(double s) {
 		return s == p.getValue() ? 1.0 : 0.0;
 	}
 
+	@Override
 	public ArrayList<Double> getSupport() {
 		return support;
 	}
 
+	@Override
 	public ArrayList<Double> getKernel() {
 		return support;
 	}
 
+	@Override
 	public String toString() {
 		return "Singleton(" + p + ")";
 	}

--- a/src/libai/fuzzy/sets/Trapezoid.java
+++ b/src/libai/fuzzy/sets/Trapezoid.java
@@ -70,10 +70,12 @@ public class Trapezoid implements FuzzySet {
 		}
 	}
 
+	@Override
 	public double eval(Variable s) {
 		return eval(s.getValue());
 	}
 
+	@Override
 	public double eval(double s) {
 		if (s < a.getValue() || s > d.getValue())
 			return 0;
@@ -86,14 +88,17 @@ public class Trapezoid implements FuzzySet {
 		return (d.getValue() - s) / (d.getValue() - c.getValue());
 	}
 
+	@Override
 	public ArrayList<Double> getSupport() {
 		return support;
 	}
 
+	@Override
 	public ArrayList<Double> getKernel() {
 		return kernel;
 	}
 
+	@Override
 	public String toString() {
 		return "Trapezoid(" + a + "," + b + "," + c + "," + d + ")";
 	}

--- a/src/libai/fuzzy/sets/Trapezoid.java
+++ b/src/libai/fuzzy/sets/Trapezoid.java
@@ -58,8 +58,8 @@ public class Trapezoid implements FuzzySet {
 
 		DELTA = delta;
 
-		kernel = new ArrayList<Double>();
-		support = new ArrayList<Double>();
+		kernel = new ArrayList<>();
+		support = new ArrayList<>();
 
 		if (DELTA > 0) {
 			for (double i = _a, max = _d; i <= max; i += DELTA) {

--- a/src/libai/fuzzy/sets/Triangular.java
+++ b/src/libai/fuzzy/sets/Triangular.java
@@ -67,10 +67,12 @@ public class Triangular implements FuzzySet {
 		this(_a, _b, _c, .5);
 	}
 
+	@Override
 	public double eval(Variable s) {
 		return eval(s.getValue());
 	}
 
+	@Override
 	public double eval(double s) {
 		if (s <= a.getValue() || s >= c.getValue())
 			return 0;
@@ -83,14 +85,17 @@ public class Triangular implements FuzzySet {
 		return (c.getValue() - s) / (c.getValue() - b.getValue());
 	}
 
+	@Override
 	public ArrayList<Double> getSupport() {
 		return support;
 	}
 
+	@Override
 	public ArrayList<Double> getKernel() {
 		return kernel;
 	}
 
+	@Override
 	public String toString() {
 		return "Triangle(" + a + "," + b + "," + c + ")";
 	}

--- a/src/libai/fuzzy/sets/Triangular.java
+++ b/src/libai/fuzzy/sets/Triangular.java
@@ -53,11 +53,11 @@ public class Triangular implements FuzzySet {
 		c = new Variable(_c);
 		DELTA = delta;
 
-		kernel = new ArrayList<Double>();
+		kernel = new ArrayList<>();
 		kernel.add(b.getValue()); //middle point
 
 		if (delta > 0) {
-			support = new ArrayList<Double>();
+			support = new ArrayList<>();
 			for (double i = Math.min(_a, Math.min(_b, _c)), max = Math.max(_a, Math.max(_b, _c)); i <= max; i += DELTA)
 				support.add(i);
 		}

--- a/src/libai/genetics/chromosomes/BinaryChromosome.java
+++ b/src/libai/genetics/chromosomes/BinaryChromosome.java
@@ -73,6 +73,7 @@ public class BinaryChromosome extends Chromosome {
 	 * @param position Position to split the chromosomes.
 	 * @return A two position array with the new offsprings.
 	 */
+	@Override
 	public Chromosome[] cross(Chromosome b, int position) {
 		BitSet aux = null;
 
@@ -96,6 +97,7 @@ public class BinaryChromosome extends Chromosome {
 	 * @param pm Mutation probability.
 	 * @return The new mutated chromosome.
 	 */
+	@Override
 	public Chromosome mutate(double pm) {
 		BitSet ret = genes.get(0, length);
 		for (int i = 0, n = length; i < n; i++) {
@@ -151,6 +153,7 @@ public class BinaryChromosome extends Chromosome {
 	 *
 	 * @return A identical chromosome of this.
 	 */
+	@Override
 	public Chromosome getCopy() {
 		return new BinaryChromosome(this);
 	}

--- a/src/libai/genetics/chromosomes/BinaryChromosome.java
+++ b/src/libai/genetics/chromosomes/BinaryChromosome.java
@@ -23,8 +23,8 @@
  */
 package libai.genetics.chromosomes;
 
-import libai.genetics.Engine;
 import java.util.BitSet;
+import libai.genetics.Engine;
 
 /**
  * The binary form of the chromosome. This chromosome contains a sequence of

--- a/src/libai/genetics/chromosomes/IntegerChromosome.java
+++ b/src/libai/genetics/chromosomes/IntegerChromosome.java
@@ -72,6 +72,7 @@ public class IntegerChromosome extends Chromosome {
 	 * @param position Omitted.
 	 * @return A two position array with the new offsprings.
 	 */
+	@Override
 	public Chromosome[] cross(Chromosome b, int position) {
 		/*int[] aux=new int[genes.length];
 		 System.arraycopy(genes,0,aux,0,position);
@@ -142,6 +143,7 @@ public class IntegerChromosome extends Chromosome {
 	 * @param pm Mutation probability.
 	 * @return The new mutated chromosome.
 	 */
+	@Override
 	public Chromosome mutate(double pm) {
 		int ret[] = new int[genes.length];
 		System.arraycopy(genes, 0, ret, 0, ret.length);
@@ -178,6 +180,7 @@ public class IntegerChromosome extends Chromosome {
 	 *
 	 * @return A identical chromosome of this.
 	 */
+	@Override
 	public Chromosome getCopy() {
 		return new IntegerChromosome(this);
 	}
@@ -189,6 +192,7 @@ public class IntegerChromosome extends Chromosome {
 	 * @param length The length of the new chromosome.
 	 * @return A new instance of length <code>length</code>
 	 */
+	@Override
 	public Chromosome getInstance(int length) {
 		return new IntegerChromosome(length);
 	}
@@ -200,6 +204,7 @@ public class IntegerChromosome extends Chromosome {
 		return genes;
 	}
 
+	@Override
 	public String toString() {
 		String ret = "";
 		for (int i = 0; i < genes.length; ret += genes[i++] + " ");

--- a/src/libai/genetics/chromosomes/IntegerChromosome.java
+++ b/src/libai/genetics/chromosomes/IntegerChromosome.java
@@ -24,8 +24,6 @@
 package libai.genetics.chromosomes;
 
 import libai.genetics.Engine;
-import libai.genetics.chromosomes.Chromosome;
-import java.util.Random;
 
 /**
  * Implementation of a permutation chromosome.

--- a/src/libai/io/MatrixIO.java
+++ b/src/libai/io/MatrixIO.java
@@ -153,7 +153,7 @@ public class MatrixIO {
     }
     
     private static void writeText(OutputStream output, Map<String, Matrix> m, String sep) throws IOException {
-        PrintStream ps = new PrintStream(output);
+        PrintStream ps = new PrintStream(output, false, "US-ASCII");
         int k = 0;
         for (Matrix matrix : m.values()) {
             for (int i = 0, r = matrix.getRows(); i < r;i++) {

--- a/src/libai/nn/NeuralNetwork.java
+++ b/src/libai/nn/NeuralNetwork.java
@@ -162,7 +162,7 @@ public abstract class NeuralNetwork implements Serializable {
 				error += Math.pow(answers[i + offset].position(j, 0) - Y.position(j, 0), 2);
 		}
 
-		return error / (double) length;
+		return error / length;
 	}
 
 	/**

--- a/src/libai/nn/NeuralNetwork.java
+++ b/src/libai/nn/NeuralNetwork.java
@@ -23,11 +23,14 @@
  */
 package libai.nn;
 
-import libai.common.ProgressDisplay;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Random;
 import libai.common.Matrix;
 import libai.common.Plotter;
-import java.io.*;
-import java.util.Random;
+import libai.common.ProgressDisplay;
 
 /**
  * Neural network abstraction. Provides the methods to train, simulate and

--- a/src/libai/nn/NeuralNetwork.java
+++ b/src/libai/nn/NeuralNetwork.java
@@ -39,6 +39,8 @@ import libai.common.ProgressDisplay;
  * @author kronenthaler
  */
 public abstract class NeuralNetwork implements Serializable {
+	private static final long serialVersionUID = 2851521924022998819L;
+	
 	protected transient Plotter plotter;
 	protected transient ProgressDisplay progress;
 

--- a/src/libai/nn/NeuralNetwork.java
+++ b/src/libai/nn/NeuralNetwork.java
@@ -167,7 +167,7 @@ public abstract class NeuralNetwork implements Serializable {
 				error += Math.pow(answers[i + offset].position(j, 0) - Y.position(j, 0), 2);
 		}
 
-		return error / length;
+		return error / (double) length;
 	}
 
 	/**

--- a/src/libai/nn/supervised/Adaline.java
+++ b/src/libai/nn/supervised/Adaline.java
@@ -36,6 +36,8 @@ import libai.common.Matrix;
  * @author kronenthaler
  */
 public class Adaline extends Perceptron {
+	private static final long serialVersionUID = 6108456796562627466L;
+	
 	public Adaline() {
 	}
 

--- a/src/libai/nn/supervised/Adaline.java
+++ b/src/libai/nn/supervised/Adaline.java
@@ -80,12 +80,17 @@ public class Adaline extends Perceptron {
 		result.add(b, result);		//bias
 	}
 
+	/**
+	 * Deserializes an {@code Adaline}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code Adaline instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static Adaline open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			Adaline p = (Adaline) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (Adaline) in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/supervised/LVQ.java
+++ b/src/libai/nn/supervised/LVQ.java
@@ -40,6 +40,8 @@ import libai.nn.unsupervised.Competitive;
  * @author kronenthaler
  */
 public class LVQ extends Competitive {
+	private static final long serialVersionUID = 6603129562167746698L;
+	
 	protected Matrix W2;
 	protected int subclasses;
 

--- a/src/libai/nn/supervised/LVQ.java
+++ b/src/libai/nn/supervised/LVQ.java
@@ -23,9 +23,9 @@
  */
 package libai.nn.supervised;
 
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
 import libai.common.Matrix;
-import java.io.*;
-import java.util.*;
 
 import libai.nn.unsupervised.Competitive;
 

--- a/src/libai/nn/supervised/LVQ.java
+++ b/src/libai/nn/supervised/LVQ.java
@@ -179,12 +179,17 @@ public class LVQ extends Competitive {
 		return (length - correct) / (double) length;
 	}
 
+	/**
+	 * Deserializes an {@code LVQ}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code LVQ instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static LVQ open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			LVQ p = (LVQ) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (LVQ) in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/supervised/MLP.java
+++ b/src/libai/nn/supervised/MLP.java
@@ -41,6 +41,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class MLP extends NeuralNetwork {
+	private static final long serialVersionUID = 3155220303024711102L;
+	
 	public static final int STANDARD_BACKPROPAGATION = 0;
 	public static final int MOMEMTUM_BACKPROPAGATION = 1;
 	public static final int RESILENT_BACKPROPAGATION = 2;

--- a/src/libai/nn/supervised/Perceptron.java
+++ b/src/libai/nn/supervised/Perceptron.java
@@ -23,11 +23,10 @@
  */
 package libai.nn.supervised;
 
-import libai.nn.NeuralNetwork;
+import java.io.*;
 import libai.common.Matrix;
 import libai.common.functions.Sign;
-import java.io.*;
-import java.util.*;
+import libai.nn.NeuralNetwork;
 
 
 /**
@@ -148,12 +147,17 @@ public class Perceptron extends NeuralNetwork {
 		result.apply(signum, result);	//thresholding
 	}
 
+	/**
+	 * Deserializes an {@code Perceptron}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code Perceptron instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static Perceptron open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			Perceptron p = (Perceptron) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (Perceptron) in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/supervised/Perceptron.java
+++ b/src/libai/nn/supervised/Perceptron.java
@@ -78,7 +78,7 @@ public class Perceptron extends NeuralNetwork {
 	@Override
 	public void train(Matrix[] patterns, Matrix[] answers, double alpha, int epochs, int offset, int length, double minerror) {
 		int[] sort = new int[length]; // [0,length)
-		double error = 1, prevError = error(patterns, answers, offset, length);
+		double error = 1;
 		Matrix Y = new Matrix(outs, 1);
 		Matrix E = new Matrix(outs, 1);
 		Matrix aux = new Matrix(outs, ins);
@@ -116,7 +116,6 @@ public class Perceptron extends NeuralNetwork {
 				b.add(E, b);  //b+(alpha*e)
 			}
 
-			prevError = error;
 			if (plotter != null)
 				plotter.setError(epochs, error);
 			if (progress != null)

--- a/src/libai/nn/supervised/Perceptron.java
+++ b/src/libai/nn/supervised/Perceptron.java
@@ -37,6 +37,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class Perceptron extends NeuralNetwork {
+	private static final long serialVersionUID = 2795822735956649552L;
+	
 	protected Matrix W, b;
 	protected int ins, outs;
 	protected static Sign signum = new Sign();

--- a/src/libai/nn/supervised/RBF.java
+++ b/src/libai/nn/supervised/RBF.java
@@ -96,7 +96,7 @@ public class RBF extends Adaline {
 		//calculate sigmas. p-closest neightbors, p is the input dimension
 		PriorityQueue<Double>[] neighbors = new PriorityQueue[nperlayer[1]];
 		for (int i = 0; i < nperlayer[1]; i++)
-			neighbors[i] = new PriorityQueue<Double>();
+			neighbors[i] = new PriorityQueue<>();
 
 		for (int i = 0; i < nperlayer[1] - 1; i++) {
 			for (int j = i + 1; j < nperlayer[1]; j++) {
@@ -156,7 +156,7 @@ public class RBF extends Adaline {
 			ctemp[i] = new Matrix(patterns[0].getRows(), patterns[0].getColumns());
 			int index = rand.nextInt(length) + offset;//abs((int)(ctemp[i].random(&xzxzx)*npatterns));;
 			patterns[index].copy(ctemp[i]);
-			partitions[i] = new ArrayList<Integer>();
+			partitions[i] = new ArrayList<>();
 		}
 		int iter = 0;
 		while (true) {

--- a/src/libai/nn/supervised/RBF.java
+++ b/src/libai/nn/supervised/RBF.java
@@ -235,12 +235,17 @@ public class RBF extends Adaline {
 		}
 	}
 
+	/**
+	 * Deserializes an {@code RBF}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code RBF instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static RBF open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			RBF p = (RBF) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (RBF) in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/supervised/RBF.java
+++ b/src/libai/nn/supervised/RBF.java
@@ -42,6 +42,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class RBF extends Adaline {
+	private static final long serialVersionUID = 6772562276994202439L;
+	
 	private Matrix c[];
 	protected int nperlayer[];//{#inputs,#Neurons,#outputs}
 	protected double[] sigma;

--- a/src/libai/nn/supervised/RBF.java
+++ b/src/libai/nn/supervised/RBF.java
@@ -195,7 +195,7 @@ public class RBF extends Adaline {
 
 					exit = false;
 				} else {
-					aux1.multiply(1.0 / total, aux);
+					aux1.multiply(1.0 / (double) total, aux);
 
 					if (!(aux.equals(ctemp[i]))) {
 						aux.copy(ctemp[i]);

--- a/src/libai/nn/supervised/RBF.java
+++ b/src/libai/nn/supervised/RBF.java
@@ -193,7 +193,7 @@ public class RBF extends Adaline {
 
 					exit = false;
 				} else {
-					aux1.multiply(1.0 / (double) total, aux);
+					aux1.multiply(1.0 / total, aux);
 
 					if (!(aux.equals(ctemp[i]))) {
 						aux.copy(ctemp[i]);

--- a/src/libai/nn/supervised/SVM.java
+++ b/src/libai/nn/supervised/SVM.java
@@ -23,13 +23,12 @@
  */
 package libai.nn.supervised;
 
-import libai.common.kernels.GaussianKernel;
-import libai.common.Matrix;
-import libai.common.kernels.Kernel;
-import libai.common.functions.SymmetricSign;
 import java.io.*;
 import java.util.*;
-
+import libai.common.Matrix;
+import libai.common.functions.SymmetricSign;
+import libai.common.kernels.GaussianKernel;
+import libai.common.kernels.Kernel;
 import libai.nn.NeuralNetwork;
 
 /**
@@ -176,17 +175,22 @@ public class SVM extends NeuralNetwork {
         result.position(0, 0, ssign.eval(learnedFunc(pattern)));
     }
 
-    public static SVM open(String path) {
-        try {
-            ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-            SVM p = (SVM) in.readObject();
-            in.close();
-            return p;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
+	/**
+	 * Deserializes an {@code SVM}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code SVM instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
+	public static SVM open(String path) {
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (SVM) in.readObject();
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
 
     @Override
     public double error(Matrix[] patterns, Matrix[] answers, int offset, int length) {

--- a/src/libai/nn/supervised/SVM.java
+++ b/src/libai/nn/supervised/SVM.java
@@ -44,6 +44,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class SVM extends NeuralNetwork {
+	private static final long serialVersionUID = 5875835056527034341L;
+	
     private Kernel kernel = new GaussianKernel(2.0);	//the default kernel type is a gaussian function
     private Matrix[] densePoints;			//array with the patterns lo learn or learned...s
     private int target[];					//expected answers

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -48,6 +48,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class Competitive extends NeuralNetwork {
+	private static final long serialVersionUID = 3792932568798202152L;
+	
 	protected Matrix W;
 	protected int ins, outs;
 	protected int winner;

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -200,7 +200,7 @@ public class Competitive extends NeuralNetwork {
 			acum += d;
 		}
 
-		return acum / length;
+		return acum / (double) length;
 	}
 
 	/**

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -23,9 +23,8 @@
  */
 package libai.nn.unsupervised;
 
-import java.io.*;
-import java.util.*;
-
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
 import libai.common.Matrix;
 import libai.nn.NeuralNetwork;
 

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -89,7 +89,6 @@ public class Competitive extends NeuralNetwork {
 	public void train(Matrix[] patterns, Matrix[] answers, double alpha, int epochs, int offset, int length, double minerror) {
 		int[] sort = new int[length]; // [0,length)
 		double error = 0;
-		Random rand = new Random();
 
 		Matrix r = new Matrix(1, ins);
 		Matrix row = new Matrix(1, ins);

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -199,7 +199,7 @@ public class Competitive extends NeuralNetwork {
 			acum += d;
 		}
 
-		return acum / (double) length;
+		return acum / length;
 	}
 
 	/**

--- a/src/libai/nn/unsupervised/Competitive.java
+++ b/src/libai/nn/unsupervised/Competitive.java
@@ -203,12 +203,17 @@ public class Competitive extends NeuralNetwork {
 		return acum / (double) length;
 	}
 
+	/**
+	 * Deserializes an {@code Competitive}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code Competitive instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static Competitive open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			Competitive p = (Competitive) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (Competitive)in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -183,7 +183,7 @@ public class Hebb extends NeuralNetwork {
 				error += Math.pow(Y.position(j, 0) - X.position(j, 0), 2);//0-1=1, 0-0=0, 1-1=0, 1-0=1
 		}
 
-		return error / (length * patterns[0].getRows());
+		return error / (double) (length * patterns[0].getRows());
 	}
 
 	/**

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -41,6 +41,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class Hebb extends NeuralNetwork {
+	private static final long serialVersionUID = 7754681003525186940L;
+	
 	protected double phi;
 	protected Matrix W;
 	protected static Sign sign = new Sign();

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -186,12 +186,17 @@ public class Hebb extends NeuralNetwork {
 		return error / (double) (length * patterns[0].getRows());
 	}
 
+	/**
+	 * Deserializes an {@code Hebb}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code Hebb instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static Hebb open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			Hebb p = (Hebb) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (Hebb)in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -90,10 +90,8 @@ public class Hebb extends NeuralNetwork {
 	 */
 	@Override
 	public void train(Matrix[] patterns, Matrix[] answers, double alpha, int epochs, int offset, int length, double minerror) {
-		Random rand = new Random();
 		int[] sort = new int[length];
 		Matrix Y = new Matrix(W.getRows(), 1);
-		Matrix temp = new Matrix(W.getRows(), W.getColumns());
 
 		Matrix[] patternsT = new Matrix[length];
 		for (int i = 0; i < length; i++) {

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -181,7 +181,7 @@ public class Hebb extends NeuralNetwork {
 				error += Math.pow(Y.position(j, 0) - X.position(j, 0), 2);//0-1=1, 0-0=0, 1-1=0, 1-0=1
 		}
 
-		return error / (double) (length * patterns[0].getRows());
+		return error / (length * patterns[0].getRows());
 	}
 
 	/**

--- a/src/libai/nn/unsupervised/Hebb.java
+++ b/src/libai/nn/unsupervised/Hebb.java
@@ -23,10 +23,10 @@
  */
 package libai.nn.unsupervised;
 
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
 import libai.common.Matrix;
 import libai.common.functions.Sign;
-import java.io.*;
-import java.util.*;
 
 import libai.nn.NeuralNetwork;
 

--- a/src/libai/nn/unsupervised/Hopfield.java
+++ b/src/libai/nn/unsupervised/Hopfield.java
@@ -25,7 +25,6 @@ package libai.nn.unsupervised;
 
 import libai.nn.NeuralNetwork;
 import java.io.*;
-import java.util.*;
 
 import libai.common.Matrix;
 import libai.common.functions.SymmetricSign;

--- a/src/libai/nn/unsupervised/Hopfield.java
+++ b/src/libai/nn/unsupervised/Hopfield.java
@@ -40,6 +40,8 @@ import libai.common.functions.SymmetricSign;
  * @author kronenthaler
  */
 public class Hopfield extends NeuralNetwork {
+	private static final long serialVersionUID = 9081060788269921587L;
+	
 	protected Matrix W;
 	protected static SymmetricSign ssign = new SymmetricSign();
 	/**

--- a/src/libai/nn/unsupervised/Hopfield.java
+++ b/src/libai/nn/unsupervised/Hopfield.java
@@ -111,12 +111,17 @@ public class Hopfield extends NeuralNetwork {
 		}
 	}
 
+	/**
+	 * Deserializes an {@code Hopfield}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code Hopfield instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static Hopfield open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			Hopfield p = (Hopfield) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (Hopfield)in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -211,8 +211,8 @@ public class Kohonen extends NeuralNetwork {
 			//take the euclidean distance to the nearest neuron in the expected cluster.
 			boolean[][] visited = new boolean[map.length][map[0].length];
 
-			ArrayList<Pair<Integer, Integer>> q = new ArrayList<Pair<Integer, Integer>>();
-			q.add(new Pair<Integer, Integer>(x, y));
+			ArrayList<Pair<Integer, Integer>> q = new ArrayList<>();
+			q.add(new Pair<>(x, y));
 			visited[x][y] = true;
 
 			while (!q.isEmpty()) {
@@ -227,7 +227,7 @@ public class Kohonen extends NeuralNetwork {
 					int ii = current.first + stepsx[k];
 					int ij = current.second + stepsy[k];
 					if (ii >= 0 && ii < nperlayer[1] && ij >= 0 && ij < nperlayer[2] && !visited[ii][ij]) {
-						q.add(new Pair<Integer, Integer>(ii, ij));
+						q.add(new Pair<>(ii, ij));
 						visited[ii][ij] = true;
 					}
 				}
@@ -280,12 +280,12 @@ public class Kohonen extends NeuralNetwork {
 				map[i][j] = (int) answers[k + offset].position(0, 0); //must have just one position and should be an integer
 		}
 
-		ArrayList<Pair<Integer, Integer>> q = new ArrayList<Pair<Integer, Integer>>();
+		ArrayList<Pair<Integer, Integer>> q = new ArrayList<>();
 
 		for (int i = 0; i < nperlayer[1]; i++)
 			for (int j = 0; j < nperlayer[2]; j++)
 				if (map[i][j] != -1)
-					q.add(new Pair<Integer, Integer>(i, j));
+					q.add(new Pair<>(i, j));
 
 		//System.out.println("BFS...");
 		while (!q.isEmpty()) {
@@ -296,7 +296,7 @@ public class Kohonen extends NeuralNetwork {
 				int i = current.first + stepsx[k];
 				int j = current.second + stepsy[k];
 				if (i >= 0 && i < nperlayer[1] && j >= 0 && j < nperlayer[2] && map[i][j] == -1) {
-					q.add(new Pair<Integer, Integer>(i, j));
+					q.add(new Pair<>(i, j));
 					map[i][j] = c;
 				}
 			}

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -147,11 +147,11 @@ public class Kohonen extends NeuralNetwork {
 
 			//update neighborhood's ratio.
 			if (neighborhood >= 0.5)
-				neighborhood = lamda * Math.exp(-(float) curr_epoch / (float) epochs);
+				neighborhood = lamda * Math.exp(-(float) curr_epoch / epochs);
 
 			//update alpha
 			if (alpha1 > 0.001)
-				alpha1 = alpha * Math.exp(-(float) curr_epoch / (float) epochs);
+				alpha1 = alpha * Math.exp(-(float) curr_epoch / epochs);
 
 			if (progress != null)
 				progress.setValue(curr_epoch);

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -42,6 +42,8 @@ import libai.nn.NeuralNetwork;
  * @author kronenthaler
  */
 public class Kohonen extends NeuralNetwork {
+	private static final long serialVersionUID = 8918172607912802829L;
+	
 	private Matrix W[];					//array of weights ijk, with k positions.
 	private int[][] map;				//map of the outputs
 	private int[] nperlayer;			//array of 3 positions, {#inputs,#rows,#columns}

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -304,12 +304,17 @@ public class Kohonen extends NeuralNetwork {
 		}
 	}
 
+	/**
+	 * Deserializes an {@code Kohonen}
+	 * 
+	 * @param path Path to file
+	 * @return Restored {@code Kohonen instance}
+	 * @see NeuralNetwork#save(java.lang.String) 
+	 */
 	public static Kohonen open(String path) {
-		try {
-			ObjectInputStream in = new ObjectInputStream(new FileInputStream(path));
-			Kohonen p = (Kohonen) in.readObject();
-			in.close();
-			return p;
+		try (FileInputStream fis = new FileInputStream(path);
+			 ObjectInputStream in = new ObjectInputStream(fis)) {
+			return (Kohonen)in.readObject();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return null;

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -149,11 +149,11 @@ public class Kohonen extends NeuralNetwork {
 
 			//update neighborhood's ratio.
 			if (neighborhood >= 0.5)
-				neighborhood = lamda * Math.exp(-(float) curr_epoch / epochs);
+				neighborhood = lamda * Math.exp(-(float) curr_epoch / (float) epochs);
 
 			//update alpha
 			if (alpha1 > 0.001)
-				alpha1 = alpha * Math.exp(-(float) curr_epoch / epochs);
+				alpha1 = alpha * Math.exp(-(float) curr_epoch / (float) epochs);
 
 			if (progress != null)
 				progress.setValue(curr_epoch);

--- a/src/libai/nn/unsupervised/Kohonen.java
+++ b/src/libai/nn/unsupervised/Kohonen.java
@@ -110,7 +110,6 @@ public class Kohonen extends NeuralNetwork {
 		double lamda = neighborhood;
 		double alpha1 = alpha;
 
-		Random rand = new Random();
 		int[] sort = new int[length];
 		for (int i = 0; i < length; sort[i] = i++);
 

--- a/src/libai/search/AStar.java
+++ b/src/libai/search/AStar.java
@@ -31,6 +31,7 @@ import java.util.*;
  * @author kronenthaler
  */
 public class AStar implements Search {
+	@Override
 	public State search(State init) {
 		PriorityQueue<State> opened = new PriorityQueue<State>();
 		HashMap<State, State> openedMirror = new HashMap<State, State>();

--- a/src/libai/search/AStar.java
+++ b/src/libai/search/AStar.java
@@ -33,9 +33,9 @@ import java.util.*;
 public class AStar implements Search {
 	@Override
 	public State search(State init) {
-		PriorityQueue<State> opened = new PriorityQueue<State>();
-		HashMap<State, State> openedMirror = new HashMap<State, State>();
-		HashMap<State, State> closed = new HashMap<State, State>();
+		PriorityQueue<State> opened = new PriorityQueue<>();
+		HashMap<State, State> openedMirror = new HashMap<>();
+		HashMap<State, State> closed = new HashMap<>();
 
 		opened.add(init);
 		openedMirror.put(init, init);

--- a/src/libai/search/BFS.java
+++ b/src/libai/search/BFS.java
@@ -31,6 +31,7 @@ import java.util.*;
  * @author kronenthaler
  */
 public class BFS implements Search {
+	@Override
 	public State search(State init) {
 		HashMap<State, Boolean> visited = new HashMap<State, Boolean>();
 		ArrayList<State> q = new ArrayList<State>();

--- a/src/libai/search/BFS.java
+++ b/src/libai/search/BFS.java
@@ -33,8 +33,8 @@ import java.util.*;
 public class BFS implements Search {
 	@Override
 	public State search(State init) {
-		HashMap<State, Boolean> visited = new HashMap<State, Boolean>();
-		ArrayList<State> q = new ArrayList<State>();
+		HashMap<State, Boolean> visited = new HashMap<>();
+		ArrayList<State> q = new ArrayList<>();
 		q.add(init);
 		visited.put(init, true);
 

--- a/src/libai/search/BFS.java
+++ b/src/libai/search/BFS.java
@@ -23,8 +23,8 @@
  */
 package libai.search;
 
-import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  *

--- a/src/libai/search/DFS.java
+++ b/src/libai/search/DFS.java
@@ -30,6 +30,7 @@ import java.util.*;
  * @author kronenthaler
  */
 public class DFS implements Search {
+	@Override
 	public State search(State init) {
 		HashMap<State, Boolean> visited = new HashMap<State, Boolean>();
 		Stack<State> q = new Stack<State>();

--- a/src/libai/search/DFS.java
+++ b/src/libai/search/DFS.java
@@ -32,8 +32,8 @@ import java.util.*;
 public class DFS implements Search {
 	@Override
 	public State search(State init) {
-		HashMap<State, Boolean> visited = new HashMap<State, Boolean>();
-		Stack<State> q = new Stack<State>();
+		HashMap<State, Boolean> visited = new HashMap<>();
+		Stack<State> q = new Stack<>();
 		q.add(init);
 		visited.put(init, true);
 

--- a/src/libai/search/State.java
+++ b/src/libai/search/State.java
@@ -51,18 +51,21 @@ public abstract class State implements Comparable<State> {
 	/**
 	 * Compare two states
 	 */
+	@Override
 	public abstract int compareTo(State o);
 
 	/**
 	 * Hash code of the state MUST BE implemented to keep track of the visited
 	 * states
 	 */
+	@Override
 	public abstract int hashCode();
 
 	/**
 	 * Determines if two states are equals or equivalents
 	 * @param o {@code o}
 	 */
+	@Override
 	public boolean equals(Object o) {
 		return compareTo((State) o) == 0;
 	}

--- a/src/libai/search/Test.java
+++ b/src/libai/search/Test.java
@@ -115,7 +115,7 @@ public class Test {
 		@Override
 		public ArrayList<State> getCandidates() {
 			//do until 4 moves.
-			ArrayList<State> candidates = new ArrayList<State>();
+			ArrayList<State> candidates = new ArrayList<>();
 			int row = point / 3;
 			int col = point % 3;
 			for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
This are another unsorted changes, _most_ of them have a reason to be:

- `Matrix#equals()` wasn't checking for type or `null`
- Since we store Matrix instances in a `Map<String, Matrix>` when serializing multiple matrices, we need a proper implementation of `Matrix#hashCode()` to avoid problems when deserializing in different `libai` instances (yes, the key of the `Map` is a `String` and not a `Matrix`, but not all maps are deserialized the same way).
- Lot's of resources weren't being closed (the `MySQLDataSet` was mostly left alone, but no statement or `ResultSet` is being properly closed, I didn't touch it, because it uses the `ResultSet` itself inside the iterator and didn't have enough time to properly test it)
- I will really start thinking about a `NNIO` class
- Add `serialVersionUID` to all serializable classes (I files serialized with `libai` compiled with OpenJDK don't work in versions compiled with OracleJDK because they lack `serialVersionUID`... I tried... *sigh*)
- About the `@Override` annotations, since I didn't write `libai`, it's fairly difficult to follow inherited methods (I'm sure that I'm not the only one).