### PR TITLE
Fix javadoc in Adaline and LVQ

### DIFF
--- a/src/libai/nn/supervised/Adaline.java
+++ b/src/libai/nn/supervised/Adaline.java
@@ -87,7 +87,7 @@ public class Adaline extends Perceptron {
 	 * 
 	 * @param path Path to file
 	 * @return Restored {@code Adaline instance}
-	 * @see NeuralNetwork#save(java.lang.String) 
+	 * @see libai.nn.NeuralNetwork#save(java.lang.String) 
 	 */
 	public static Adaline open(String path) {
 		try (FileInputStream fis = new FileInputStream(path);

--- a/src/libai/nn/supervised/Adaline.java
+++ b/src/libai/nn/supervised/Adaline.java
@@ -2,17 +2,17 @@
  * MIT License
  *
  * Copyright (c) 2009-2016 Ignacio Calderon <https://github.com/kronenthaler>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,16 +28,16 @@ import libai.common.Matrix;
 
 /**
  * <b>Ada</b>ptative <b>Line</b>ar neural network. Is a special case of the
- * single layer Perceptron. Uses a identity as exit function. The only 
- * difference between the training algorithms is the 2*alpha multiplication. 
- * Because of this, the Adaline implementation is a subclass of Perceptron 
+ * single layer Perceptron. Uses a identity as exit function. The only
+ * difference between the training algorithms is the 2*alpha multiplication.
+ * Because of this, the Adaline implementation is a subclass of Perceptron
  * single layer.
  *
  * @author kronenthaler
  */
 public class Adaline extends Perceptron {
 	private static final long serialVersionUID = 6108456796562627466L;
-	
+
 	public Adaline() {
 	}
 
@@ -84,10 +84,10 @@ public class Adaline extends Perceptron {
 
 	/**
 	 * Deserializes an {@code Adaline}
-	 * 
+	 *
 	 * @param path Path to file
 	 * @return Restored {@code Adaline instance}
-	 * @see libai.nn.NeuralNetwork#save(java.lang.String) 
+	 * @see libai.nn.NeuralNetwork#save(java.lang.String)
 	 */
 	public static Adaline open(String path) {
 		try (FileInputStream fis = new FileInputStream(path);

--- a/src/libai/nn/supervised/LVQ.java
+++ b/src/libai/nn/supervised/LVQ.java
@@ -2,17 +2,17 @@
  * MIT License
  *
  * Copyright (c) 2009-2016 Ignacio Calderon <https://github.com/kronenthaler>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -41,7 +41,7 @@ import libai.nn.unsupervised.Competitive;
  */
 public class LVQ extends Competitive {
 	private static final long serialVersionUID = 6603129562167746698L;
-	
+
 	protected Matrix W2;
 	protected int subclasses;
 
@@ -183,10 +183,10 @@ public class LVQ extends Competitive {
 
 	/**
 	 * Deserializes an {@code LVQ}
-	 * 
+	 *
 	 * @param path Path to file
 	 * @return Restored {@code LVQ instance}
-	 * @see libai.nn.NeuralNetwork#save(java.lang.String) 
+	 * @see libai.nn.NeuralNetwork#save(java.lang.String)
 	 */
 	public static LVQ open(String path) {
 		try (FileInputStream fis = new FileInputStream(path);

--- a/src/libai/nn/supervised/LVQ.java
+++ b/src/libai/nn/supervised/LVQ.java
@@ -186,7 +186,7 @@ public class LVQ extends Competitive {
 	 * 
 	 * @param path Path to file
 	 * @return Restored {@code LVQ instance}
-	 * @see NeuralNetwork#save(java.lang.String) 
+	 * @see libai.nn.NeuralNetwork#save(java.lang.String) 
 	 */
 	public static LVQ open(String path) {
 		try (FileInputStream fis = new FileInputStream(path);


### PR DESCRIPTION
We should check if there's a way to make travis fail if javadoc contains an error